### PR TITLE
#41 푸시 알림 옵션 로컬 저장 + 프로필 공개

### DIFF
--- a/core/data/src/main/java/com/startup/data/annotations/UserTokenDataStore.kt
+++ b/core/data/src/main/java/com/startup/data/annotations/UserTokenDataStore.kt
@@ -5,3 +5,11 @@ import javax.inject.Qualifier
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class UserTokenDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class UserSettingDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class UserNotificationDataStore

--- a/core/data/src/main/java/com/startup/data/datasource/UserDataSource.kt
+++ b/core/data/src/main/java/com/startup/data/datasource/UserDataSource.kt
@@ -1,0 +1,14 @@
+package com.startup.data.datasource
+
+import kotlinx.coroutines.flow.Flow
+
+interface UserDataSource {
+    suspend fun getNotificationTodayStepEnabled(): Flow<Boolean>
+    suspend fun updateNotificationTodayStepEnabled(enabled: Boolean)
+    suspend fun getNotificationSpotArriveEnabled(): Flow<Boolean>
+    suspend fun updateNotificationSpotArriveEnabled(enabled: Boolean)
+    suspend fun getNotificationEggHatchEnabled(): Flow<Boolean>
+    suspend fun updateNotificationEggHatchEnabled(enabled: Boolean)
+    suspend fun getProfileAccessEnabled(): Flow<Boolean>
+    suspend fun updateProfileAccessEnabled(enabled: Boolean)
+}

--- a/core/data/src/main/java/com/startup/data/di/DataSourceModule.kt
+++ b/core/data/src/main/java/com/startup/data/di/DataSourceModule.kt
@@ -9,7 +9,9 @@ import com.startup.data.datasource.ReviewDataSource
 import com.startup.data.datasource.SpotDataSource
 import com.startup.data.datasource.Temp2DataSource
 import com.startup.data.datasource.TempDataSource
+import com.startup.data.datasource.UserDataSource
 import com.startup.data.local.datasourceimpl.Temp2DataSourceImpl
+import com.startup.data.local.datasourceimpl.UserDataSourceImpl
 import com.startup.data.remote.datasourceimpl.AuthDataSourceImpl
 import com.startup.data.remote.datasourceimpl.CharacterDataSourceImpl
 import com.startup.data.remote.datasourceimpl.EggDataSourceImpl
@@ -65,6 +67,10 @@ internal abstract class DataSourceModule {
     @Singleton
     @Binds
     abstract fun bindsAuthDataSource(dataSource: AuthDataSourceImpl): AuthDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindsUserDataSource(dataSource: UserDataSourceImpl): UserDataSource
 
     @Singleton
     @Binds

--- a/core/data/src/main/java/com/startup/data/di/DataStoreModule.kt
+++ b/core/data/src/main/java/com/startup/data/di/DataStoreModule.kt
@@ -1,8 +1,12 @@
 package com.startup.data.di
 
 import com.startup.data.local.datasourceimpl.StepDataStoreImpl
-import com.startup.data.util.TokenDataStoreProvider
-import com.startup.data.util.TokenDataStoreProviderImpl
+import com.startup.data.local.provider.NotificationDataStoreProvider
+import com.startup.data.local.provider.NotificationDataStoreProviderImpl
+import com.startup.data.local.provider.TokenDataStoreProvider
+import com.startup.data.local.provider.TokenDataStoreProviderImpl
+import com.startup.data.local.provider.UserSettingDataStoreProvider
+import com.startup.data.local.provider.UserSettingDataStoreProviderImpl
 import com.startup.domain.provider.StepDataStore
 import dagger.Binds
 import dagger.Module
@@ -21,4 +25,12 @@ internal abstract class DataStoreModule {
     @Singleton
     @Binds
     abstract fun bindSettingPreferenceDataStoreProvider(tokenDataStoreProvider: TokenDataStoreProviderImpl): TokenDataStoreProvider
+
+    @Singleton
+    @Binds
+    abstract fun bindNotificationPreferenceDataStoreProvider(notificationDataStoreProvider: NotificationDataStoreProviderImpl): NotificationDataStoreProvider
+
+    @Singleton
+    @Binds
+    abstract fun bindUserSettingPreferenceDataStoreProvider(userSettingDataStoreProvider: UserSettingDataStoreProviderImpl): UserSettingDataStoreProvider
 }

--- a/core/data/src/main/java/com/startup/data/di/DataStoreObjectModule.kt
+++ b/core/data/src/main/java/com/startup/data/di/DataStoreObjectModule.kt
@@ -3,10 +3,19 @@ package com.startup.data.di
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.startup.data.annotations.UserNotificationDataStore
+import com.startup.data.annotations.UserSettingDataStore
 import com.startup.data.annotations.UserTokenDataStore
 import com.startup.data.util.ACCESS_TOKEN_KEY_NAME
+import com.startup.data.util.NOTIFICATION_EGG_HATCH_KEY_NAME
+import com.startup.data.util.NOTIFICATION_SPOT_ARRIVE_KEY_NAME
+import com.startup.data.util.NOTIFICATION_TODAY_STEP_KEY_NAME
+import com.startup.data.util.PROFILE_ACCESS_KEY_NAME
 import com.startup.data.util.REFRESH_ACCESS_TOKEN_KEY_NAME
+import com.startup.data.util.userNotificationDataStore
+import com.startup.data.util.userSettingDataStore
 import com.startup.data.util.userTokenDataStore
 import dagger.Module
 import dagger.Provides
@@ -25,10 +34,42 @@ internal object DataStoreObjectModule {
         context.userTokenDataStore
 
     @Provides
+    @UserNotificationDataStore
+    fun provideUserNotificationPreferenceDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        context.userNotificationDataStore
+
+    @Provides
+    @UserSettingDataStore
+    fun provideUserSettingPreferenceDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        context.userSettingDataStore
+
+    @Provides
     @Named(REFRESH_ACCESS_TOKEN_KEY_NAME)
-    fun providesAccessTokenKey(): Preferences.Key<String> = stringPreferencesKey(REFRESH_ACCESS_TOKEN_KEY_NAME)
+    fun providesAccessTokenKey(): Preferences.Key<String> =
+        stringPreferencesKey(REFRESH_ACCESS_TOKEN_KEY_NAME)
 
     @Provides
     @Named(ACCESS_TOKEN_KEY_NAME)
-    fun providesRefreshTokenKey(): Preferences.Key<String> = stringPreferencesKey(ACCESS_TOKEN_KEY_NAME)
+    fun providesRefreshTokenKey(): Preferences.Key<String> =
+        stringPreferencesKey(ACCESS_TOKEN_KEY_NAME)
+
+    @Provides
+    @Named(NOTIFICATION_TODAY_STEP_KEY_NAME)
+    fun providesNotificationTodayStepKey(): Preferences.Key<Boolean> =
+        booleanPreferencesKey(NOTIFICATION_TODAY_STEP_KEY_NAME)
+
+    @Provides
+    @Named(NOTIFICATION_SPOT_ARRIVE_KEY_NAME)
+    fun providesNotificationSpotArriveKey(): Preferences.Key<Boolean> =
+        booleanPreferencesKey(NOTIFICATION_SPOT_ARRIVE_KEY_NAME)
+
+    @Provides
+    @Named(NOTIFICATION_EGG_HATCH_KEY_NAME)
+    fun providesNotificationEggHatchKey(): Preferences.Key<Boolean> =
+        booleanPreferencesKey(NOTIFICATION_EGG_HATCH_KEY_NAME)
+
+    @Provides
+    @Named(PROFILE_ACCESS_KEY_NAME)
+    fun providesProfileAccessKey(): Preferences.Key<Boolean> =
+        booleanPreferencesKey(PROFILE_ACCESS_KEY_NAME)
 }

--- a/core/data/src/main/java/com/startup/data/local/datasourceimpl/UserDataSourceImpl.kt
+++ b/core/data/src/main/java/com/startup/data/local/datasourceimpl/UserDataSourceImpl.kt
@@ -1,0 +1,50 @@
+package com.startup.data.local.datasourceimpl
+
+import androidx.datastore.preferences.core.Preferences
+import com.startup.data.datasource.UserDataSource
+import com.startup.data.local.provider.NotificationDataStoreProvider
+import com.startup.data.local.provider.UserSettingDataStoreProvider
+import com.startup.data.util.NOTIFICATION_EGG_HATCH_KEY_NAME
+import com.startup.data.util.NOTIFICATION_SPOT_ARRIVE_KEY_NAME
+import com.startup.data.util.NOTIFICATION_TODAY_STEP_KEY_NAME
+import com.startup.data.util.PROFILE_ACCESS_KEY_NAME
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Named
+
+internal class UserDataSourceImpl @Inject constructor(
+    private val notificationDataStoreProvider: NotificationDataStoreProvider,
+    private val userSettingDataStoreProvider: UserSettingDataStoreProvider,
+    @Named(NOTIFICATION_TODAY_STEP_KEY_NAME) private val notificationTodayStepKey: Preferences.Key<Boolean>,
+    @Named(NOTIFICATION_SPOT_ARRIVE_KEY_NAME) private val notificationSpotArriveKey: Preferences.Key<Boolean>,
+    @Named(NOTIFICATION_EGG_HATCH_KEY_NAME) private val notificationEggHatchKey: Preferences.Key<Boolean>,
+    @Named(PROFILE_ACCESS_KEY_NAME) private val profileAccessKey: Preferences.Key<Boolean>,
+) : UserDataSource {
+    override suspend fun getNotificationTodayStepEnabled(): Flow<Boolean> =
+        notificationDataStoreProvider.getFlowValue(notificationTodayStepKey)
+
+    override suspend fun updateNotificationTodayStepEnabled(enabled: Boolean) {
+        notificationDataStoreProvider.putValue(notificationTodayStepKey, enabled)
+    }
+
+    override suspend fun getNotificationSpotArriveEnabled(): Flow<Boolean> =
+        notificationDataStoreProvider.getFlowValue(notificationSpotArriveKey)
+
+    override suspend fun updateNotificationSpotArriveEnabled(enabled: Boolean) {
+        notificationDataStoreProvider.putValue(notificationSpotArriveKey, enabled)
+    }
+
+    override suspend fun getNotificationEggHatchEnabled(): Flow<Boolean> =
+        notificationDataStoreProvider.getFlowValue(notificationEggHatchKey)
+
+    override suspend fun updateNotificationEggHatchEnabled(enabled: Boolean) {
+        notificationDataStoreProvider.putValue(notificationEggHatchKey, enabled)
+    }
+
+    override suspend fun getProfileAccessEnabled(): Flow<Boolean> =
+        userSettingDataStoreProvider.getFlowValue(profileAccessKey)
+
+    override suspend fun updateProfileAccessEnabled(enabled: Boolean) {
+        userSettingDataStoreProvider.putValue(profileAccessKey, enabled)
+    }
+}

--- a/core/data/src/main/java/com/startup/data/local/provider/NotificationDataStoreProvider.kt
+++ b/core/data/src/main/java/com/startup/data/local/provider/NotificationDataStoreProvider.kt
@@ -1,0 +1,5 @@
+package com.startup.data.local.provider
+
+import com.startup.data.util.DataStoreProvider
+
+interface NotificationDataStoreProvider : DataStoreProvider

--- a/core/data/src/main/java/com/startup/data/local/provider/NotificationDataStoreProviderImpl.kt
+++ b/core/data/src/main/java/com/startup/data/local/provider/NotificationDataStoreProviderImpl.kt
@@ -1,18 +1,16 @@
-package com.startup.data.util
+package com.startup.data.local.provider
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
-import com.startup.data.annotations.UserTokenDataStore
+import com.startup.data.annotations.UserNotificationDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
-internal class TokenDataStoreProviderImpl @Inject constructor(@UserTokenDataStore private val preferencesDataStore: DataStore<Preferences>) : TokenDataStoreProvider {
+internal class NotificationDataStoreProviderImpl @Inject constructor(@UserNotificationDataStore private val preferencesDataStore: DataStore<Preferences>): NotificationDataStoreProvider {
     override suspend fun <T> putValue(key: Preferences.Key<T>, value: T) {
         preferencesDataStore.edit { it[key] = value }
     }

--- a/core/data/src/main/java/com/startup/data/local/provider/TokenDataStoreProvider.kt
+++ b/core/data/src/main/java/com/startup/data/local/provider/TokenDataStoreProvider.kt
@@ -1,0 +1,5 @@
+package com.startup.data.local.provider
+
+import com.startup.data.util.DataStoreProvider
+
+interface TokenDataStoreProvider : DataStoreProvider

--- a/core/data/src/main/java/com/startup/data/local/provider/TokenDataStoreProviderImpl.kt
+++ b/core/data/src/main/java/com/startup/data/local/provider/TokenDataStoreProviderImpl.kt
@@ -1,0 +1,32 @@
+package com.startup.data.local.provider
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import com.startup.data.annotations.UserTokenDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import javax.inject.Inject
+
+internal class TokenDataStoreProviderImpl @Inject constructor(@UserTokenDataStore private val preferencesDataStore: DataStore<Preferences>) :
+    TokenDataStoreProvider {
+    override suspend fun <T> putValue(key: Preferences.Key<T>, value: T) {
+        preferencesDataStore.edit { it[key] = value }
+    }
+
+    override suspend fun <T> getValue(key: Preferences.Key<T>, defaultValue: T): T {
+        return preferencesDataStore.data.map {
+            it[key]
+        }.firstOrNull() ?: defaultValue
+    }
+
+    override fun <T> getFlowValue(key: Preferences.Key<T>): Flow<T> {
+        return preferencesDataStore.data.mapNotNull { it[key] }
+    }
+
+    override suspend fun clearAllData() {
+        preferencesDataStore.edit { it.clear() }
+    }
+}

--- a/core/data/src/main/java/com/startup/data/local/provider/UserSettingDataStoreProvider.kt
+++ b/core/data/src/main/java/com/startup/data/local/provider/UserSettingDataStoreProvider.kt
@@ -1,0 +1,5 @@
+package com.startup.data.local.provider
+
+import com.startup.data.util.DataStoreProvider
+
+interface UserSettingDataStoreProvider : DataStoreProvider

--- a/core/data/src/main/java/com/startup/data/local/provider/UserSettingDataStoreProviderImpl.kt
+++ b/core/data/src/main/java/com/startup/data/local/provider/UserSettingDataStoreProviderImpl.kt
@@ -1,0 +1,32 @@
+package com.startup.data.local.provider
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import com.startup.data.annotations.UserSettingDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import javax.inject.Inject
+
+internal class UserSettingDataStoreProviderImpl @Inject constructor(@UserSettingDataStore private val preferencesDataStore: DataStore<Preferences>) :
+    UserSettingDataStoreProvider {
+    override suspend fun <T> putValue(key: Preferences.Key<T>, value: T) {
+        preferencesDataStore.edit { it[key] = value }
+    }
+
+    override suspend fun <T> getValue(key: Preferences.Key<T>, defaultValue: T): T {
+        return preferencesDataStore.data.map {
+            it[key]
+        }.firstOrNull() ?: defaultValue
+    }
+
+    override fun <T> getFlowValue(key: Preferences.Key<T>): Flow<T> {
+        return preferencesDataStore.data.mapNotNull { it[key] }
+    }
+
+    override suspend fun clearAllData() {
+        preferencesDataStore.edit { it.clear() }
+    }
+}

--- a/core/data/src/main/java/com/startup/data/remote/datasourceimpl/AuthDataSourceImpl.kt
+++ b/core/data/src/main/java/com/startup/data/remote/datasourceimpl/AuthDataSourceImpl.kt
@@ -11,7 +11,7 @@ import com.startup.data.remote.service.MemberService
 import com.startup.data.util.ACCESS_TOKEN_KEY_NAME
 import com.startup.data.util.KaKaoLoginClient
 import com.startup.data.util.REFRESH_ACCESS_TOKEN_KEY_NAME
-import com.startup.data.util.TokenDataStoreProvider
+import com.startup.data.local.provider.TokenDataStoreProvider
 import com.startup.data.util.handleExceptionIfNeed
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow

--- a/core/data/src/main/java/com/startup/data/util/AuthInterceptor.kt
+++ b/core/data/src/main/java/com/startup/data/util/AuthInterceptor.kt
@@ -3,6 +3,7 @@ package com.startup.data.util
 import androidx.datastore.preferences.core.Preferences
 import com.startup.common.util.Printer
 import com.startup.common.util.SessionExpireException
+import com.startup.data.local.provider.TokenDataStoreProvider
 import com.startup.data.remote.service.AuthService
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor

--- a/core/data/src/main/java/com/startup/data/util/DataStoreProvider.kt
+++ b/core/data/src/main/java/com/startup/data/util/DataStoreProvider.kt
@@ -3,7 +3,7 @@ package com.startup.data.util
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.flow.Flow
 
-interface TokenDataStoreProvider {
+interface DataStoreProvider {
     suspend fun <T> putValue(key: Preferences.Key<T>, value: T)
     suspend fun <T> getValue(key: Preferences.Key<T>, defaultValue: T): T
     fun <T> getFlowValue(key: Preferences.Key<T>): Flow<T>

--- a/core/data/src/main/java/com/startup/data/util/DataStoreUtils.kt
+++ b/core/data/src/main/java/com/startup/data/util/DataStoreUtils.kt
@@ -7,8 +7,20 @@ import androidx.datastore.preferences.preferencesDataStore
 
 
 private const val TOKEN_DATA_STORE_FILE_NAME = "walkie_token"
+private const val NOTIFICATION_DATA_STORE_FILE_NAME = "walkie_notification"
+private const val USER_SETTING_DATA_STORE_FILE_NAME = "walkie_user_setting"
 
 internal const val ACCESS_TOKEN_KEY_NAME = "AccessToken"
 internal const val REFRESH_ACCESS_TOKEN_KEY_NAME = "RefreshToken"
 
+internal const val NOTIFICATION_TODAY_STEP_KEY_NAME = "NotificationTodayStep"
+internal const val NOTIFICATION_SPOT_ARRIVE_KEY_NAME = "NotificationSpotArrive"
+internal const val NOTIFICATION_EGG_HATCH_KEY_NAME = "NotificationEggHatch"
+
+internal const val PROFILE_ACCESS_KEY_NAME = "ProfileAccess"
+
 internal val Context.userTokenDataStore: DataStore<Preferences> by preferencesDataStore(name = TOKEN_DATA_STORE_FILE_NAME)
+
+internal val Context.userNotificationDataStore: DataStore<Preferences> by preferencesDataStore(name = NOTIFICATION_DATA_STORE_FILE_NAME)
+
+internal val Context.userSettingDataStore: DataStore<Preferences> by preferencesDataStore(name = USER_SETTING_DATA_STORE_FILE_NAME)


### PR DESCRIPTION
- Resolved : #41 

### 변경사항
- DataStoreProvider Base 로 분리
- 푸시 알림용(Notification), 프로필 설정 (UserSetting) 용 데이터 분리
- UserDataSource 로 합쳤습니다!
- 화면은 없어서 아직은 일단 datasource 단까지만 연결 했어요!
- Flow<Boolean> 으로 받은 이유는 stateIn 으로 저장하려고 한 것입니닷