### PR TITLE
#53 스플래시 네비게이션 판단 로직 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
         </activity>
 
         <activity
-            android:name=".SplashActivity"
+            android:name=".splash.SplashActivity"
             android:exported="true"
             android:theme="@style/Theme.Walkie.Splash">
             <intent-filter>

--- a/core/common/src/main/java/com/startup/common/base/Event.kt
+++ b/core/common/src/main/java/com/startup/common/base/Event.kt
@@ -8,4 +8,4 @@ interface Event : BaseEvent
 interface NavigationEvent : BaseEvent {
     object Back : NavigationEvent
 }
-interface ScreenNavigationEvent : BaseEvent
+interface ScreenNavigationEvent : NavigationEvent

--- a/core/common/src/main/java/com/startup/common/base/UiEvent.kt
+++ b/core/common/src/main/java/com/startup/common/base/UiEvent.kt
@@ -1,3 +1,3 @@
 package com.startup.common.base
 
-interface UiEvent
+interface UiEvent: BaseEvent

--- a/core/common/src/main/java/com/startup/common/util/CustomExceptions.kt
+++ b/core/common/src/main/java/com/startup/common/util/CustomExceptions.kt
@@ -24,6 +24,7 @@ class NetworkTemporaryException(
 
 class ResponseErrorException(
     override val message: String,
+    val code: Int? = null
 ) : Exception(message), WalkieException
 
 class KakaoAuthFailException(

--- a/core/data/src/main/java/com/startup/data/remote/BaseResponse.kt
+++ b/core/data/src/main/java/com/startup/data/remote/BaseResponse.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class BaseResponse<T : Any?>(
     @SerializedName("success")
-    val success: Boolean?,
+    val status: Int?,
     @SerializedName("message")
     val message: String?,
     @SerializedName("data")

--- a/core/data/src/main/java/com/startup/data/remote/datasourceimpl/AuthDataSourceImpl.kt
+++ b/core/data/src/main/java/com/startup/data/remote/datasourceimpl/AuthDataSourceImpl.kt
@@ -45,7 +45,7 @@ internal class AuthDataSourceImpl @Inject constructor(
     override fun login(): Flow<Unit> = callbackFlow {
         kakaoLogin().map {
             val item = authService.login(it)
-            if (item.success != true) {
+            if (item.status != 200) {
                 throw ResponseErrorException(item.message.orEmpty())
             }
             item.data.requireNotNull()

--- a/core/data/src/main/java/com/startup/data/remote/datasourceimpl/MemberDataSourceImpl.kt
+++ b/core/data/src/main/java/com/startup/data/remote/datasourceimpl/MemberDataSourceImpl.kt
@@ -19,7 +19,7 @@ internal class MemberDataSourceImpl @Inject constructor(private val memberServic
     MemberDataSource {
     override fun getUserInfo(): Flow<GetUserInfoResponse> = flow {
         handleExceptionIfNeed {
-            emitRemote(memberService.getUserInfo())
+            emitRemote(memberService.getUserInfo(), specificErrorCode = 204)
         }
     }
 

--- a/core/data/src/main/java/com/startup/data/remote/ext/RemoteExtension.kt
+++ b/core/data/src/main/java/com/startup/data/remote/ext/RemoteExtension.kt
@@ -4,9 +4,15 @@ import com.startup.common.util.ResponseErrorException
 import com.startup.data.remote.BaseResponse
 import kotlinx.coroutines.flow.FlowCollector
 
-internal suspend fun <T : BaseResponse<R>, R> FlowCollector<R>.emitRemote(item: T) {
-    if (item.success != true) {
-        throw ResponseErrorException(item.message.orEmpty())
+internal suspend fun <T : BaseResponse<R>, R> FlowCollector<R>.emitRemote(
+    item: T,
+    specificErrorCode: Int? = null
+) {
+    if (specificErrorCode != null && item.status == specificErrorCode) {
+        throw ResponseErrorException(item.message.orEmpty(), item.status)
+    }
+    if (item.status !in 200..299) {
+        throw ResponseErrorException(item.message.orEmpty(), (item.status ?: -1))
     }
     emit(item.data.requireNotNull())
 }

--- a/core/data/src/main/java/com/startup/data/util/AuthInterceptor.kt
+++ b/core/data/src/main/java/com/startup/data/util/AuthInterceptor.kt
@@ -49,7 +49,7 @@ internal class AuthInterceptor @Inject constructor(
             val refreshResponse =
                 runCatching { authService.refreshTokenUpdate(BEARER + refreshToken) }.getOrNull()
             val data = refreshResponse?.data
-            if (refreshResponse?.success != true || data == null) {
+            if (refreshResponse?.status != 200 || data == null) {
                 throw SessionExpireException("세션 만료")
             } else {
                 tokenDataStoreProvider.putValue(accessTokenKey, data.accessToken.orEmpty())

--- a/core/domain/src/main/java/com/startup/domain/usecase/GetMyData.kt
+++ b/core/domain/src/main/java/com/startup/domain/usecase/GetMyData.kt
@@ -1,0 +1,11 @@
+package com.startup.domain.usecase
+
+import com.startup.domain.model.member.UserInfo
+import com.startup.domain.repository.MemberRepository
+import com.startup.domain.util.BaseUseCase
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetMyData @Inject constructor(private val memberRepository: MemberRepository) : BaseUseCase<UserInfo, Unit>() {
+    override fun invoke(params: Unit): Flow<UserInfo> = memberRepository.getUserInfo()
+}

--- a/feature/login/src/main/kotlin/com/startup/walkie/splash/SplashActivity.kt
+++ b/feature/login/src/main/kotlin/com/startup/walkie/splash/SplashActivity.kt
@@ -1,13 +1,12 @@
-package com.startup.walkie
+package com.startup.walkie.splash
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -16,35 +15,53 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
+import com.startup.common.base.BaseActivity
+import com.startup.common.util.Printer
 import com.startup.login.R
 import com.startup.ui.WalkieTheme
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
-class SplashActivity : ComponentActivity() {
+@AndroidEntryPoint
+class SplashActivity : BaseActivity<SplashUiEvent, SplashNavigationEvent>() {
+    override val viewModel: SplashViewModel by viewModels<SplashViewModel>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             SplashScreenCompose()
         }
-        checkUserLogin()
+        handleNavigationEvent(viewModel.event.filterIsInstance())
     }
 
-    private fun checkUserLogin() {
-        lifecycleScope.launch {
-            delay(2000)
-            // TODO 자동 로그인 여부 확인
-            // TODO 첫 사용자 인지 확인
-        }
+    override fun handleNavigationEvent(navigationEventFlow: Flow<SplashNavigationEvent>) {
+        navigationEventFlow.onEach {
+            Printer.e("LMH", "EVENT $it")
+            when(it) {
+                SplashNavigationEvent.MoveToMainActivity -> {
+                    // TODO 이동
+                }
+                SplashNavigationEvent.MoveToOnBoarding -> {
+                    // TODO 이동
+                }
+                SplashNavigationEvent.MoveToOnBoardingAndNickNameSet -> {
+                    // TODO 이동
+                }
+            }
+        }.launchIn(lifecycleScope)
     }
+
+    override fun handleUiEvent(uiEvent: SplashUiEvent) {}
 }
 
 @Composable
-fun SplashScreenCompose() {
+private fun SplashScreenCompose() {
     Box(
         modifier = Modifier
             .fillMaxSize()

--- a/feature/login/src/main/kotlin/com/startup/walkie/splash/SplashContract.kt
+++ b/feature/login/src/main/kotlin/com/startup/walkie/splash/SplashContract.kt
@@ -1,0 +1,15 @@
+package com.startup.walkie.splash
+
+import com.startup.common.base.ScreenNavigationEvent
+import com.startup.common.base.UiEvent
+
+
+sealed interface SplashUiEvent : UiEvent {
+
+}
+
+sealed interface SplashNavigationEvent : ScreenNavigationEvent {
+    data object MoveToMainActivity : SplashNavigationEvent
+    data object MoveToOnBoardingAndNickNameSet : SplashNavigationEvent
+    data object MoveToOnBoarding : SplashNavigationEvent
+}

--- a/feature/login/src/main/kotlin/com/startup/walkie/splash/SplashViewModel.kt
+++ b/feature/login/src/main/kotlin/com/startup/walkie/splash/SplashViewModel.kt
@@ -1,0 +1,31 @@
+package com.startup.walkie.splash
+
+import androidx.lifecycle.viewModelScope
+import com.startup.common.base.BaseViewModel
+import com.startup.common.base.State
+import com.startup.domain.usecase.GetMyData
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(getMyData: GetMyData) : BaseViewModel() {
+    override val state: State = object : State {}
+
+    init {
+        getMyData.invoke(Unit).onEach {
+            delay(2_000)
+            if (it.memberNickName.isBlank()) {
+                notifyEvent(SplashNavigationEvent.MoveToOnBoardingAndNickNameSet)
+            } else {
+                notifyEvent(SplashNavigationEvent.MoveToMainActivity)
+            }
+        }.catch {
+            delay(2_000)
+            notifyEvent(SplashNavigationEvent.MoveToOnBoarding)
+        }.launchIn(viewModelScope)
+    }
+}


### PR DESCRIPTION
- Resolved : #53 

### 변경사항
- Event 에 대한 상속관계 변경
- BaseResponse 변경될 구조로 변경 (status 가 필요했기에 미리 적용)
- emitRemote 에서 2XX 제외로는 에러로 판별하게 했는데 204 같은 특별하게 코드를 판단 해야하는 경우 해당 케이스 에러 처리하도록 emiteRemote 변경

### 유저 데이터를 조회로 이동 판단
- 204 에러, 일반 에러, 세션 관련 에러 등은 온보딩으로 이동
- 유저 데이터는 오는데 닉네임이 비어있으면 온보딩 => 닉네임 입력하는 위치로 이동
- 유저 데이터 있으면 메인 액티비티