### PR TITLE
#75 권한 허용 플로우 및 바텀시트 추가

### DIFF
--- a/core/common/src/main/java/com/startup/common/util/ComposePermissionRequestDelegator.kt
+++ b/core/common/src/main/java/com/startup/common/util/ComposePermissionRequestDelegator.kt
@@ -1,5 +1,7 @@
 package com.startup.common.util
 
+import android.content.Context
+import android.content.ContextWrapper
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -9,13 +11,29 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.app.ActivityCompat
 import com.startup.common.extension.moveToAppDetailSetting
+import java.lang.ref.WeakReference
+
+/**
+ * Context에서 ComponentActivity를 찾는 확장 함수
+ */
+fun Context.findComponentActivity(): ComponentActivity? {
+    var currentContext = this
+    while (currentContext is ContextWrapper) {
+        if (currentContext is ComponentActivity) {
+            return currentContext
+        }
+        currentContext = currentContext.baseContext
+    }
+    return null
+}
+
 
 abstract class ComposePermissionRequestDelegator(
-    private val activity: ComponentActivity,
+    private val activity: WeakReference<ComponentActivity>,
     doOnGranted: () -> Unit,
     doOnShouldShowRequestPermissionRationale: (List<String>) -> Unit = {},
     doOnNeverAskAgain: (List<String>) -> Unit = {
-        activity.moveToAppDetailSetting() // 앱 세부 설정으로 이동하는 함수
+        activity.get()?.moveToAppDetailSetting() // 앱 세부 설정으로 이동하는 함수
     },
 ) : BaseComposePermissionRequestDelegator(
     doOnGranted = doOnGranted,
@@ -23,7 +41,8 @@ abstract class ComposePermissionRequestDelegator(
     doOnShouldShowRequestPermissionRationale = doOnShouldShowRequestPermissionRationale,
 ) {
     override fun shouldShowRequestPermissionRationale(permission: String): Boolean {
-        return ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)
+        return activity.get()
+            ?.let { ActivityCompat.shouldShowRequestPermissionRationale(it, permission) } ?: false
     }
 }
 
@@ -33,10 +52,12 @@ fun rememberPermissionRequestDelegator(
     doOnGranted: () -> Unit,
     doOnShouldShowRequestPermissionRationale: (List<String>) -> Unit = {},
     doOnNeverAskAgain: (List<String>) -> Unit = {},
-): ComposePermissionRequestDelegator {
-    val context = LocalContext.current as ComponentActivity
+): ComposePermissionRequestDelegator? {
+    val context = LocalContext.current
+    val componentActivity = context.findComponentActivity() ?: return null
+
     fun shouldShowRequestPermissionRationale(permission: String): Boolean {
-        return ActivityCompat.shouldShowRequestPermissionRationale(context, permission)
+        return ActivityCompat.shouldShowRequestPermissionRationale(componentActivity, permission)
     }
 
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -61,16 +82,19 @@ fun rememberPermissionRequestDelegator(
             .takeIf { it.isNotEmpty() }
             ?.let { doOnNeverAskAgain(it) }
     }
+    val activityRef = remember { WeakReference(componentActivity) }
+
     return remember {
         object : ComposePermissionRequestDelegator(
-            activity = context,
+            activity = activityRef,
             doOnGranted = doOnGranted,
             doOnShouldShowRequestPermissionRationale = doOnShouldShowRequestPermissionRationale,
             doOnNeverAskAgain = doOnNeverAskAgain
         ) {
             override val requestPermissionType: UsePermissionHelper.Permission
                 get() = permission
-            override val permissionLauncher: ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>> = permissionLauncher
+            override val permissionLauncher: ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>> =
+                permissionLauncher
         }
     }
 }

--- a/core/common/src/main/java/com/startup/common/util/UsePermissionHelper.kt
+++ b/core/common/src/main/java/com/startup/common/util/UsePermissionHelper.kt
@@ -2,7 +2,10 @@ package com.startup.common.util
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
 import androidx.core.content.ContextCompat
 
 object UsePermissionHelper {
@@ -55,7 +58,7 @@ object UsePermissionHelper {
 
     private val PERMISSION_RECORD_AUDIO = arrayOf(Manifest.permission.RECORD_AUDIO)
 
-    private val PERMISSION_STEP_COUNTER = if (OsVersions.isGreaterThanOrEqualsQ()) {
+    private val PERMISSION_ACTIVITY_RECOGNITION = if (OsVersions.isGreaterThanOrEqualsQ()) {
         arrayOf(Manifest.permission.ACTIVITY_RECOGNITION)
     } else {
         arrayOf()
@@ -71,7 +74,7 @@ object UsePermissionHelper {
             Permission.CAMERA -> PERMISSION_CAMERA
             Permission.POST_NOTIFICATIONS -> PERMISSION_NOTIFICATION
             Permission.RECORD_AUDIO -> PERMISSION_RECORD_AUDIO
-            Permission.STEP_COUNTER -> PERMISSION_STEP_COUNTER
+            Permission.ACTIVITY_RECOGNITION -> PERMISSION_ACTIVITY_RECOGNITION
             Permission.BATTERY_OPTIMIZATION -> PERMISSION_BATTERY_OPTIMIZATION
         }
     }
@@ -93,6 +96,12 @@ object UsePermissionHelper {
         }
     }
 
+    fun getPermissionSettingsIntent(context: Context): Intent {
+        return Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", context.packageName, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
 
     enum class Permission {
         GALLERY,
@@ -100,7 +109,7 @@ object UsePermissionHelper {
         FILE,
         RECORD_AUDIO,
         POST_NOTIFICATIONS,
-        STEP_COUNTER,
+        ACTIVITY_RECOGNITION,
         BATTERY_OPTIMIZATION
     }
 }

--- a/feature/home/src/main/java/com/startup/home/HomeActivity.kt
+++ b/feature/home/src/main/java/com/startup/home/HomeActivity.kt
@@ -1,15 +1,7 @@
 package com.startup.home
 
-import android.Manifest
-import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Bundle
-import android.os.PowerManager
-import android.provider.Settings
 import androidx.activity.compose.setContent
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -19,11 +11,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.core.content.ContextCompat
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -32,10 +31,15 @@ import androidx.navigation.navArgument
 import com.startup.common.base.BaseActivity
 import com.startup.common.base.NavigationEvent
 import com.startup.common.base.UiEvent
+import com.startup.common.util.BatteryOptimizationHelper
 import com.startup.common.util.OsVersions
+import com.startup.common.util.UsePermissionHelper
+import com.startup.design_system.widget.bottom_sheet.WalkieDragHandle
 import com.startup.home.navigation.HomeNavigationGraph
 import com.startup.home.navigation.MainScreenNav
 import com.startup.home.navigation.MyPageNavigationGraph
+import com.startup.home.permission.PermissionBottomSheet
+import com.startup.home.permission.PermissionState
 import com.startup.navigation.HomeFeatureNavigator
 import com.startup.ui.WalkieTheme
 import dagger.hilt.EntryPoint
@@ -44,21 +48,17 @@ import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class HomeActivity : BaseActivity<UiEvent, NavigationEvent>() {
     override val viewModel: HomeViewModel by viewModels<HomeViewModel>()
 
-    private val requiredPermissions = if (OsVersions.isGreaterThanOrEqualsTIRAMISU()) {
-        arrayOf(
-            Manifest.permission.POST_NOTIFICATIONS,
-            Manifest.permission.ACTIVITY_RECOGNITION
-        )
-    } else if (OsVersions.isGreaterThanOrEqualsQ()) {
-        arrayOf(Manifest.permission.ACTIVITY_RECOGNITION)
-    } else {
-        arrayOf()
-    }
+    // 권한 바텀시트 표시 여부 상태
+    private var shouldShowPermissionBottomSheet by mutableStateOf(false)
+
+    // 권한 상태 리스트
+    private var permissionStates by mutableStateOf<List<PermissionState>>(emptyList())
 
     // KSP 는 필드 주입이 안 됨
     private val homeFeatureNavigator: HomeFeatureNavigator by lazy {
@@ -77,44 +77,114 @@ class HomeActivity : BaseActivity<UiEvent, NavigationEvent>() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        checkBatteryOptimization()
-        checkAndRequestPermissions()
+        checkPermission()
 
         setContent {
             WalkieTheme {
-                MainScreen()
+                MainScreenWithPermissionBottomSheet()
             }
         }
     }
 
-    private fun checkBatteryOptimization() {
-        val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
-        if (!powerManager.isIgnoringBatteryOptimizations(packageName)) {
-            Intent().apply {
-                action = Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
-                data = Uri.parse("package:$packageName")
-                startActivity(this)
-            }
-        }
-    }
+    private fun checkPermission() {
+        initPermissionStates()
+        val allPermissionsGranted = areAllPermissionsGranted()
 
-    private fun checkAndRequestPermissions() {
-        if (!hasRequiredPermissions()) {
-            registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-                if (permissions.all { it.value }) {
-                    startStepCounterService()
-                }
-            }.launch(requiredPermissions)
-        } else {
+        if (allPermissionsGranted) {
             startStepCounterService()
+            shouldShowPermissionBottomSheet = false
+        } else {
+            shouldShowPermissionBottomSheet = true
         }
     }
 
-    private fun hasRequiredPermissions(): Boolean {
-        return requiredPermissions.all { permission ->
-            ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    fun MainScreenWithPermissionBottomSheet() {
+        val sheetState = rememberModalBottomSheetState()
+        val coroutineScope = rememberCoroutineScope()
+
+        Box(modifier = Modifier.fillMaxSize()) {
+            MainScreen()
+
+            if (shouldShowPermissionBottomSheet) {
+                ModalBottomSheet(
+                    onDismissRequest = {
+                        shouldShowPermissionBottomSheet = false
+                        if (!areAllPermissionsGranted()) {
+                            // 권한 미허용시 앱종료 추후 기획에 따라 조건 변동
+                            finish()
+                        }
+                    },
+                    sheetState = sheetState,
+                    tonalElevation = 24.dp,
+                    dragHandle = {
+                        WalkieDragHandle()
+                    },
+                    containerColor = WalkieTheme.colors.white,
+                    contentColor = WalkieTheme.colors.white,
+                    scrimColor = WalkieTheme.colors.blackOpacity60,
+                ) {
+                    PermissionBottomSheet(
+                        permissions = permissionStates,
+                        onAllPermissionsGranted = {
+                            startStepCounterService()
+                            coroutineScope.launch {
+                                sheetState.hide()
+                                shouldShowPermissionBottomSheet = false
+                            }
+                        }
+                    )
+                }
+            }
         }
+    }
+
+
+    private fun initPermissionStates() {
+        val states = mutableListOf<PermissionState>()
+
+        if (OsVersions.isGreaterThanOrEqualsTIRAMISU()) {
+            states.add(
+                PermissionState(
+                    type = UsePermissionHelper.Permission.POST_NOTIFICATIONS,
+                    isGranted = isGranted(UsePermissionHelper.Permission.POST_NOTIFICATIONS),
+                    title = "알림 권한",
+                    description = "알림을 받기 위해 필요합니다."
+                )
+            )
+        }
+
+        if (OsVersions.isGreaterThanOrEqualsQ()) {
+            states.add(
+                PermissionState(
+                    type = UsePermissionHelper.Permission.ACTIVITY_RECOGNITION,
+                    isGranted = isGranted(UsePermissionHelper.Permission.ACTIVITY_RECOGNITION),
+                    title = "신체 활동 권한",
+                    description = "걸음 수 측정을 위해 필요합니다."
+                )
+            )
+        }
+
+        states.add(
+            PermissionState(
+                type = UsePermissionHelper.Permission.BATTERY_OPTIMIZATION,
+                isGranted = BatteryOptimizationHelper.isBatteryOptimizationIgnored(this),
+                title = "배터리 최적화 제외",
+                description = "앱이 백그라운드에서도 정확하게 동작하기 위해 필요합니다."
+            )
+        )
+
+        permissionStates = states
+    }
+
+    private fun areAllPermissionsGranted(): Boolean {
+        return permissionStates.all { it.isGranted }
+    }
+
+    private fun isGranted(permission: UsePermissionHelper.Permission): Boolean {
+        val permissions = UsePermissionHelper.getTypeOfPermission(permission)
+        return UsePermissionHelper.isGrantedPermissions(this, *permissions)
     }
 
     private fun startStepCounterService() {
@@ -129,7 +199,6 @@ class HomeActivity : BaseActivity<UiEvent, NavigationEvent>() {
     fun MainScreen() {
         MainContent()
     }
-
 
     @Composable
     fun MainContent() {

--- a/feature/home/src/main/java/com/startup/home/permission/PermissionInduction.kt
+++ b/feature/home/src/main/java/com/startup/home/permission/PermissionInduction.kt
@@ -1,0 +1,316 @@
+package com.startup.home.permission
+
+import android.content.Context
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.startup.common.util.BatteryOptimizationHelper
+import com.startup.common.util.UsePermissionHelper
+import com.startup.ui.WalkieTheme
+
+/**
+ * 권한 상태를 나타내는 데이터 클래스
+ */
+data class PermissionState(
+    val type: UsePermissionHelper.Permission,
+    val isGranted: Boolean,
+    val title: String,
+    val description: String
+)
+
+/**
+ * 권한 요청을 처리하는 바텀시트
+ */
+@Composable
+fun PermissionBottomSheet(
+    permissions: List<PermissionState>,
+    onAllPermissionsGranted: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    // 권한 상태 추적
+    val permissionsState =
+        remember { mutableStateListOf<PermissionState>().apply { addAll(permissions) } }
+
+    // 모든 권한이 허용되었는지 확인
+    val allPermissionsGranted = permissionsState.all { it.isGranted }
+
+    // 권한 분류 - 배터리 최적화를 제외한 일반 권한
+    val normalPermissions = permissionsState.filter {
+        it.type != UsePermissionHelper.Permission.BATTERY_OPTIMIZATION && !it.isGranted
+    }
+
+    // 배터리 최적화 권한 필요 여부
+    val hasBatteryOptimization = permissionsState.any {
+        it.type == UsePermissionHelper.Permission.BATTERY_OPTIMIZATION && !it.isGranted
+    }
+
+    // 권한 거부 카운트 추적 (영구 거절 감지용)
+    val permissionDeniedCount =
+        remember { mutableStateMapOf<UsePermissionHelper.Permission, Int>() }
+
+    // 일반 권한 요청을 위한 런처
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { resultMap ->
+        updatePermissionStates(resultMap, permissionsState, permissionDeniedCount, context)
+
+        // 모든 권한이 허용되었는지 확인
+        if (permissionsState.all { it.isGranted }) {
+            onAllPermissionsGranted()
+        }
+    }
+
+
+    // todo 무조건 바꿔야함
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                WalkieTheme.colors.white,
+                RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+            )
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "앱 권한 설정",
+            style = WalkieTheme.typography.head1,
+            color = WalkieTheme.colors.gray700,
+            modifier = Modifier.padding(vertical = 8.dp)
+        )
+
+        Text(
+            text = "앱을 제대로 사용하기 위해 아래 권한이 필요합니다.",
+            color = WalkieTheme.colors.blue300,
+            style = WalkieTheme.typography.body2,
+        )
+
+        permissionsState.forEach { permission ->
+            PermissionItemWithoutButton(permissionState = permission)
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (!allPermissionsGranted) {
+            Button(
+                onClick = {
+                    requestPermissions(
+                        normalPermissions = normalPermissions,
+                        hasBatteryOptimization = hasBatteryOptimization,
+                        permissionLauncher = permissionLauncher,
+                        context = context,
+                        permissionsState = permissionsState
+                    )
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            ) {
+                Text(text = "모든 권한 허용하기")
+            }
+
+            Button(
+                onClick = { openAppSettings(context) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Settings,
+                        contentDescription = "Settings",
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = "설정에서 권한 허용")
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 권한 상태 업데이트 함수
+ */
+private fun updatePermissionStates(
+    resultMap: Map<String, Boolean>,
+    permissionsState: SnapshotStateList<PermissionState>,
+    permissionDeniedCount: SnapshotStateMap<UsePermissionHelper.Permission, Int>,
+    context: Context
+) {
+    resultMap.forEach { (permission, isGranted) ->
+        // 해당 권한에 맞는 Permission 타입 찾기
+        val permissionType = permissionsState.find { state ->
+            UsePermissionHelper.getTypeOfPermission(state.type).contains(permission)
+        }?.type ?: return@forEach
+
+        if (isGranted) {
+            // 허용된 권한 업데이트
+            val index = permissionsState.indexOfFirst { it.type == permissionType }
+            if (index != -1) {
+                permissionsState[index] = permissionsState[index].copy(isGranted = true)
+            }
+        } else {
+            // 거부된 권한 카운트 증가
+            permissionDeniedCount[permissionType] = (permissionDeniedCount[permissionType] ?: 0) + 1
+
+            // 영구 거절의 경우 거부된 경우 설정으로 이동
+            if ((permissionDeniedCount[permissionType] ?: 0) >= 2) {
+                openAppSettings(context)
+            }
+        }
+    }
+}
+
+/**
+ * 권한 요청 함수
+ */
+private fun requestPermissions(
+    normalPermissions: List<PermissionState>,
+    hasBatteryOptimization: Boolean,
+    permissionLauncher: ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>>,
+    context: Context,
+    permissionsState: SnapshotStateList<PermissionState>
+) {
+    // 일반 권한 요청
+    if (normalPermissions.isNotEmpty()) {
+        val permissionsToRequest = normalPermissions
+            .flatMap { UsePermissionHelper.getTypeOfPermission(it.type).toList() }
+            .toTypedArray()
+
+        if (permissionsToRequest.isNotEmpty()) {
+            permissionLauncher.launch(permissionsToRequest)
+        }
+    }
+
+    // 배터리 최적화 권한 요청
+    if (hasBatteryOptimization && !BatteryOptimizationHelper.isBatteryOptimizationIgnored(context)) {
+        openBatteryOptimizationSettings(context)
+
+        // 배터리 최적화 상태 업데이트
+        val index = permissionsState.indexOfFirst {
+            it.type == UsePermissionHelper.Permission.BATTERY_OPTIMIZATION
+        }
+        if (index != -1) {
+            permissionsState[index] = permissionsState[index].copy(isGranted = true)
+        }
+    }
+}
+
+/**
+ * 권한 항목 컴포넌트
+ */
+@Composable
+fun PermissionItemWithoutButton(permissionState: PermissionState) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = if (permissionState.isGranted) Icons.Default.Check else Icons.Default.Warning,
+            contentDescription = "Permission status",
+            tint = if (permissionState.isGranted) WalkieTheme.colors.gray400 else WalkieTheme.colors.blue300
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(end = 8.dp)
+        ) {
+            Text(
+                text = permissionState.title,
+                style = WalkieTheme.typography.body1,
+                color = WalkieTheme.colors.gray700
+            )
+
+            Text(
+                text = permissionState.description,
+                style = WalkieTheme.typography.caption1,
+                color = WalkieTheme.colors.gray500
+            )
+        }
+    }
+}
+
+/**
+ * 시스템 설정의 앱 상세 화면으로 이동하는 함수
+ */
+fun openAppSettings(context: Context) {
+    val intent = UsePermissionHelper.getPermissionSettingsIntent(context)
+    context.startActivity(intent)
+}
+
+/**
+ * 배터리 최적화 설정 화면으로 이동하는 함수
+ */
+fun openBatteryOptimizationSettings(context: Context) {
+    val intent = BatteryOptimizationHelper.getBatteryOptimizationSettingsIntent(context)
+    context.startActivity(intent)
+}
+
+@Preview(name = "All Permissions Granted", showBackground = true)
+@Composable
+fun PermissionBottomSheetAllGrantedPreview() {
+    WalkieTheme {
+        PermissionBottomSheet(
+            permissions = listOf(
+                PermissionState(
+                    type = UsePermissionHelper.Permission.ACTIVITY_RECOGNITION,
+                    isGranted = true,
+                    title = "신체 활동 권한",
+                    description = "걸음수 측정을 위해서 필요합니다."
+                ),
+                PermissionState(
+                    type = UsePermissionHelper.Permission.POST_NOTIFICATIONS,
+                    isGranted = true,
+                    title = "카메라",
+                    description = "정확한 걸음수 측정과 알림 수신을 위해 필요합니다."
+                ),
+                PermissionState(
+                    type = UsePermissionHelper.Permission.BATTERY_OPTIMIZATION,
+                    isGranted = true,
+                    title = "배터리 최적화 제외",
+                    description = "백그라운드에서 앱이 원활하게 작동하기 위해 필요합니다."
+                )
+            ),
+            onAllPermissionsGranted = {}
+        )
+    }
+}


### PR DESCRIPTION
resolved : #75
- 권한 허용 플로우를 위해 미리 권한 허용 관련 로직들 UsePermissionHelper 사용하여 구현해두었습니다.
- 바텀시트 형태로 할거 같아서 나중에 UI만 따로 변경할 정도로만 구현했습니다.
- 직접 activity를 찾으려고 하면 ClassCastException 발생해서 ContextWrapper 활용해서 activity 찾는 함수 하나 추가해두었습니다.