### PR TITLE
#79 자정 감지 브로드캐스트 리시버 추가 및 걸음수 초기화 업로드 로직 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
@@ -68,7 +70,9 @@
         <activity
             android:name="com.startup.home.HomeActivity"
             android:exported="false"
-            android:theme="@style/Theme.Walkie" />
+            android:theme="@style/Theme.Walkie">
+
+        </activity>
 
         <activity
             android:name=".splash.SplashActivity"
@@ -84,7 +88,9 @@
         <activity
             android:name=".login.LoginActivity"
             android:exported="false"
-            android:theme="@style/Theme.Walkie" />
+            android:theme="@style/Theme.Walkie">
+
+        </activity>
         <activity
             android:name="com.startup.spot.SpotActivity"
             android:exported="false"

--- a/core/domain/src/main/java/com/startup/domain/provider/StepDataStore.kt
+++ b/core/domain/src/main/java/com/startup/domain/provider/StepDataStore.kt
@@ -9,4 +9,10 @@ interface StepDataStore {
     suspend fun setTargetStep(target: Int)
     suspend fun resetSteps()
     fun observeSteps(): Flow<Int>
+
+    // 걸음수 초기화 관련 로직
+    suspend fun isLastResetToday(): Boolean
+    suspend fun saveLastResetDate()
+    suspend fun saveYesterdaySteps(steps: Int)
+    suspend fun getYesterdaySteps(): Int
 }

--- a/feature/home/src/main/java/com/startup/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/startup/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.viewModelScope
 import com.startup.common.base.BaseViewModel
 import com.startup.common.base.State
+import com.startup.domain.repository.SpotRepository
 import com.startup.stepcounter.service.StepCounterService
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -13,6 +14,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val stepCounter: StepCounterService,
+    private val spotRepository: SpotRepository
 ) : BaseViewModel() {
     private val _state = mutableStateOf(StepCounterState())
     override val state: State
@@ -39,6 +41,35 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             stepCounter.resetSteps()
         }
+    }
+
+    fun initTodayStep() {
+        viewModelScope.launch {
+            val previousSteps = stepCounter.checkAndResetForNewDay()
+
+            // 이전 걸음 수가 있으면 업로드 및 UI 업데이트
+            previousSteps?.let { steps ->
+                uploadYesterdaySteps(steps)
+            }
+        }
+    }
+
+    private fun uploadYesterdaySteps(steps: Int) {
+        // todo 실제 usecase로 핸들링
+//        uploadStepUseCase.executeOnViewModel(
+//            params = steps,
+//            onEach = {
+//                // 업로드 성공 시 UI 업데이트
+//                updateMainActivity()
+//            },
+//            onError = { error ->
+//                // 에러 처리
+//            }
+//        ).launchIn(viewModelScope)
+    }
+
+    private fun updateMainActivity() {
+        // todo view 업데이트
     }
 }
 

--- a/feature/stepcounter/src/main/java/com/startup/stepcounter/broadcastReciver/DailyResetReceiver.kt
+++ b/feature/stepcounter/src/main/java/com/startup/stepcounter/broadcastReciver/DailyResetReceiver.kt
@@ -1,0 +1,38 @@
+package com.startup.stepcounter.broadcastReciver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import java.lang.ref.WeakReference
+
+class DailyResetReceiver : BroadcastReceiver() {
+
+    interface OnDateChangedListener {
+        fun onDateChanged()
+    }
+
+    private var onDateChangedListener: WeakReference<OnDateChangedListener>? = null
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (context == null || intent == null) return
+
+
+        when (intent.action) {
+            Intent.ACTION_DATE_CHANGED -> {
+                notifyDateChanged()
+            }
+        }
+    }
+
+    private fun notifyDateChanged() {
+        onDateChangedListener?.get()?.onDateChanged()
+    }
+
+    fun setOnDateChangedListener(listener: OnDateChangedListener) {
+        this.onDateChangedListener = WeakReference(listener)
+    }
+
+    fun removeOnDateChangedListener() {
+        this.onDateChangedListener = null
+    }
+}

--- a/feature/stepcounter/src/main/java/com/startup/stepcounter/broadcastReciver/PackageChangedReceiver.kt
+++ b/feature/stepcounter/src/main/java/com/startup/stepcounter/broadcastReciver/PackageChangedReceiver.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
  * 앱 업데이트를 감지하여 서비스를 재시작하는 브로드캐스트 리시버
  */
 @AndroidEntryPoint
-class PackageChangedReceiver @Inject constructor() : BroadcastReceiver(){
+internal class PackageChangedReceiver @Inject constructor() : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
         if (Objects.equals(intent?.action, Intent.ACTION_MY_PACKAGE_REPLACED)) {


### PR DESCRIPTION
- Resolved : #79 

- 자정시점을 감지하여 초기화 하는 브로드캐스트 추가했습니다. 다만, 브로드캐스트리시버라 앱의 포그라운드일때만 동작합니다. 
- 추가로 서버 걸음수 업로드 대비 한 로직들 몇가지 추가해두었습니다. 

제가 생각하는 서버 업로드 시점은 다음과 같습니다, 


- 기기시간 기준 자정이 지났을때, 앱 진입한 경우 (데이터 보존개념으로)
- 알이 부화 준비가 되어서 앱 진입한 경우 

서비스에서 서버호출을 하는게 괜찮을까 고민되어서 혹시 어떻게 생각하세요?