### PR TITLE
#36 보유한 캐릭터 화면 및 보유기록 바텀시트 추가

### DIFF
--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -26,6 +26,9 @@
     <string name="current_step">\u0020%s걸음</string>
 
 
+    <string name="format_int">%d</string>
+    <string name="format_string">%s</string>
+    <string name="format_float">%f</string>
     <string name="quantity_string">%d개</string>
     <string name="group_characters_string">%d마리</string>
 
@@ -79,6 +82,42 @@
     <string name="onboarding_3_sub_title">스팟까지 안내해 줄 캐릭터를 선택하고\n함께 모험을 떠나 보세요.</string>
     <string name="onboarding_4_title">나만의 모험 기록</string>
     <string name="onboarding_4_sub_title">스팟을 모험하며 얻은\n경험을 모아보세요</string>
+    <string name="hatching_characters">부화한 캐릭터</string>
+    <string name="character_jellyfish">해파리</string>
+    <string name="character_jellyfish_description">육지에서 뛰고 싶은 꿈을 가진 낭만적인 해파리들</string>
+    <string name="character_dino_description">사람들과 뛰어놀고 싶어서 먼 과거에서 돌아온 다이노들</string>
+    <string name="character_dino">다이노</string>
+    <string name="character_detail_wise_saying">무엇이든 시작에는 큰 용기가 필요해.\n나와 함께 첫걸음을 내딛어보자.</string>
+    <string name="character_count">마리</string>
+    <string name="character_gain_count">마리 보유</string>
+    <string name="character_not_gain">미획득</string>
+    <string name="character_gain_induction">알을 부화시켜 얻어요</string>
+    <string name="character_partner_select">이 캐릭터와 같이 걷기</string>
+    <string name="character_already_selected">같이 걷는 중…</string>
+
+
+    <string name="jellyfish_basic">해파리</string>
+    <string name="jellyfish_red">빨간 해파리</string>
+    <string name="jellyfish_green">초록 해파리</string>
+    <string name="jellyfish_purple">보라 해파리</string>
+    <string name="jellyfish_pink">분홍 해파리</string>
+    <string name="jellyfish_rabbit">토끼 해파리</string>
+    <string name="jellyfish_starfish">불가사리 해파리</string>
+    <string name="jellyfish_electric_shock">빠직 해파리</string>
+    <string name="jellyfish_strawberry_ricecake">딸기모찌 해파리</string>
+    <string name="jellyfish_space">우주 해파리</string>
+
+    <string name="dino_basic">다이노</string>
+    <string name="dino_red">빨간 다이노</string>
+    <string name="dino_mint">민트 다이노</string>
+    <string name="dino_purple">보라 다이노</string>
+    <string name="dino_pink">분홍 다이노</string>
+    <string name="dino_reindeer">순록 다이노</string>
+    <string name="dino_ness">네시 다이노</string>
+    <string name="dino_pancake">팬케이크 다이노</string>
+    <string name="dino_melon_soda">메론소다 다이노</string>
+    <string name="dino_dragon">드래곤 다이노</string>
+
     <string name="calendar_date_select">이동하기</string>
     <string name="calendar_review_title">기록</string>
     <string name="calendar_review_walk_together">와 함께 걸었어요</string>

--- a/feature/home/src/main/java/com/startup/home/character/HatchingCharacterScreen.kt
+++ b/feature/home/src/main/java/com/startup/home/character/HatchingCharacterScreen.kt
@@ -1,0 +1,677 @@
+package com.startup.home.character
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
+import androidx.compose.ui.unit.dp
+import com.startup.common.base.NavigationEvent
+import com.startup.design_system.widget.actionbar.PageActionBar
+import com.startup.design_system.widget.actionbar.PageActionBarType
+import com.startup.design_system.widget.bottom_sheet.WalkieDragHandle
+import com.startup.design_system.widget.button.PrimaryButton
+import com.startup.design_system.widget.tag.TagMedium
+import com.startup.home.R
+import com.startup.home.character.model.CharacterFactory
+import com.startup.home.character.model.WalkieCharacter
+import com.startup.ui.WalkieTheme
+import com.startup.ui.WalkieTheme.colors
+import com.startup.ui.noRippleClickable
+import kotlinx.coroutines.launch
+
+object CharacterTabType {
+    const val JELLYFISH = 0
+    const val DINO = 1
+}
+
+@Composable
+fun HatchingCharacterScreen(onNavigationEvent: (NavigationEvent) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.white)
+    ) {
+        PageActionBar(PageActionBarType.JustBackActionBarType {
+            onNavigationEvent.invoke(NavigationEvent.Back)
+        })
+
+        val scrollState = rememberScrollState()
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(horizontal = 16.dp)
+        ) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(R.string.hatching_characters),
+                style = WalkieTheme.typography.head2
+            )
+            Spacer(modifier = Modifier.height(22.dp))
+            CharacterTabsContent()
+        }
+    }
+}
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CharacterTabsContent() {
+    val characterTypes = listOf(
+        stringResource(R.string.character_jellyfish),
+        stringResource(R.string.character_dino)
+    )
+
+    val pagerState =
+        rememberPagerState(initialPage = CharacterTabType.JELLYFISH) { characterTypes.size }
+    val coroutineScope = rememberCoroutineScope()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    var showBottomSheet by remember { mutableStateOf(false) }
+
+    //todo state로 관리
+    var selectedCharacter by remember { mutableStateOf<WalkieCharacter?>(null) }
+    var viewingCharacter by remember { mutableStateOf<WalkieCharacter?>(null) }
+
+    Column {
+        CharacterTypeTabs(
+            characterTypes = characterTypes,
+            currentPage = pagerState.currentPage,
+            onTabSelected = { index ->
+                coroutineScope.launch {
+                    pagerState.animateScrollToPage(index)
+                }
+            }
+        )
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxWidth()
+        ) { page ->
+            CharacterContentByType(
+                tabIndex = page,
+                selectedCharacter = selectedCharacter,
+                onCharacterClick = { character ->
+                    viewingCharacter = character
+                    showBottomSheet = true
+                }
+            )
+        }
+
+        if (showBottomSheet) {
+            CharacterDetailBottomSheet(
+                sheetState = sheetState,
+                character = viewingCharacter,
+                selectedCharacter = selectedCharacter,
+                onDismiss = {
+                    showBottomSheet = false
+                },
+                onSelectPartner = { character ->
+                    selectedCharacter = character
+                    showBottomSheet = false
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun CharacterTypeTabs(
+    characterTypes: List<String>,
+    currentPage: Int,
+    onTabSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.wrapContentWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        characterTypes.forEachIndexed { index, type ->
+            CharacterTab(
+                text = type,
+                selected = index == currentPage,
+                onClick = { onTabSelected(index) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun CharacterContentByType(
+    tabIndex: Int,
+    selectedCharacter: WalkieCharacter?,
+    onCharacterClick: (WalkieCharacter) -> Unit
+) {
+    when (tabIndex) {
+        CharacterTabType.JELLYFISH -> JellyfishContent(
+            selectedCharacter = selectedCharacter,
+            onCharacterClick = onCharacterClick
+        )
+
+        CharacterTabType.DINO -> DinosaurContent(
+            selectedCharacter = selectedCharacter,
+            onCharacterClick = onCharacterClick
+        )
+    }
+}
+
+@Composable
+fun CharacterTab(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .noRippleClickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = text,
+                style = WalkieTheme.typography.head3,
+                color = if (selected) colors.gray700 else colors.gray400
+            )
+        }
+    }
+}
+
+@Composable
+fun JellyfishContent(
+    selectedCharacter: WalkieCharacter?,
+    onCharacterClick: (WalkieCharacter) -> Unit
+) {
+    val jellyfishCharacters = CharacterFactory.getJellyfishCharacters()
+
+    // todo fetch
+    // 첫 번째와 세 번째 캐릭터만 empty(미획득)로 가정
+    val emptyCharacterIds =
+        remember { listOf(jellyfishCharacters[0].id, jellyfishCharacters[2].id) }
+
+    CharacterGrid(
+        description = stringResource(id = R.string.character_jellyfish_description),
+        characters = jellyfishCharacters,
+        selectedCharacter = selectedCharacter,
+        emptyCharacterIds = emptyCharacterIds,
+        onCharacterClick = onCharacterClick,
+        currentTab = CharacterTabType.JELLYFISH,
+    )
+}
+
+@Composable
+fun DinosaurContent(
+    selectedCharacter: WalkieCharacter?,
+    onCharacterClick: (WalkieCharacter) -> Unit
+) {
+    // todo fetch
+    // 첫 번째와 세 번째 캐릭터만 empty(미획득)로 가정
+    val dinoCharacters = CharacterFactory.getDinoCharacters()
+    val emptyCharacterIds = remember { listOf(dinoCharacters[1].id, dinoCharacters[3].id) }
+
+    CharacterGrid(
+        description = stringResource(id = R.string.character_dino_description),
+        characters = dinoCharacters,
+        selectedCharacter = selectedCharacter,
+        emptyCharacterIds = emptyCharacterIds,
+        onCharacterClick = onCharacterClick,
+        currentTab = CharacterTabType.DINO,
+    )
+}
+
+@Composable
+fun CharacterGrid(
+    description: String,
+    characters: List<WalkieCharacter>,
+    selectedCharacter: WalkieCharacter?,
+    emptyCharacterIds: List<String>,
+    currentTab: Int,
+    onCharacterClick: (WalkieCharacter) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Text(
+            text = description,
+            style = WalkieTheme.typography.body2,
+            color = colors.gray500,
+            modifier = Modifier.padding(top = 4.dp, bottom = 20.dp)
+        )
+
+        CharacterGridItems(
+            characters = characters,
+            selectedCharacter = selectedCharacter,
+            emptyCharacterIds = emptyCharacterIds,
+            currentTab = currentTab,
+            onCharacterClick = onCharacterClick
+        )
+    }
+}
+
+@Composable
+private fun CharacterGridItems(
+    characters: List<WalkieCharacter>,
+    selectedCharacter: WalkieCharacter?,
+    emptyCharacterIds: List<String>,
+    currentTab: Int,
+    onCharacterClick: (WalkieCharacter) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val rows = characters.chunked(2)
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(bottom = 48.dp)
+    ) {
+        rows.forEach { rowCharacters ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                rowCharacters.forEach { character ->
+                    Box(modifier = Modifier.weight(1f)) {
+                        CharacterItem(
+                            character = character,
+                            isSelected = character.id == selectedCharacter?.id,
+                            isEmpty = emptyCharacterIds.contains(character.id),
+                            currentTab = currentTab,
+                            onClick = { onCharacterClick(character) }
+                        )
+                    }
+                }
+
+                // 마지막 행이 홀수 개일 경우 빈 공간 추가
+                if (rowCharacters.size == 1) {
+                    Box(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CharacterItem(
+    modifier: Modifier = Modifier,
+    character: WalkieCharacter,
+    isSelected: Boolean = false,
+    isEmpty: Boolean = false,
+    currentTab: Int = CharacterTabType.JELLYFISH,
+    onClick: (WalkieCharacter) -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .noRippleClickable { onClick(character) }
+            .then(
+                if (isSelected) {
+                    Modifier.border(
+                        width = 2.dp,
+                        color = colors.blue300,
+                        shape = RoundedCornerShape(20.dp)
+                    )
+                } else Modifier
+            )
+            .aspectRatio(1f)
+            .background(
+                color = colors.gray100,
+                shape = RoundedCornerShape(20.dp)
+            )
+            .padding(8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        if (isSelected) {
+            Icon(
+                painter = painterResource(R.drawable.ic_foot),
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 4.dp, end = 4.dp),
+                contentDescription = stringResource(R.string.desc_egg_play_icon),
+                tint = colors.blue300
+            )
+        }
+
+        CharacterItemContent(
+            character = character,
+            isEmpty = isEmpty,
+            currentTab = currentTab
+        )
+    }
+}
+
+@Composable
+private fun CharacterItemContent(
+    character: WalkieCharacter,
+    isEmpty: Boolean,
+    currentTab: Int
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Image(
+            painter = painterResource(
+                id = if (isEmpty) {
+                    when (currentTab) {
+                        CharacterTabType.JELLYFISH -> R.drawable.jelly_empty
+                        CharacterTabType.DINO -> R.drawable.dino_empty
+                        else -> character.imageResource
+                    }
+                } else {
+                    character.imageResource
+                }
+            ),
+            contentDescription = stringResource(id = character.nameResId),
+            modifier = Modifier
+                .fillMaxWidth(0.6f) // 작은 기기 대응
+                .sizeIn(maxWidth = 120.dp, maxHeight = 120.dp)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        if (isEmpty) {
+            Text(
+                text = stringResource(id = R.string.character_not_gain),
+                style = WalkieTheme.typography.head5.copy(color = colors.gray500),
+            )
+            Text(
+                text = stringResource(id = R.string.character_gain_induction),
+                style = WalkieTheme.typography.body2.copy(color = colors.gray400),
+            )
+        } else {
+            Text(
+                text = stringResource(id = character.nameResId),
+                style = WalkieTheme.typography.head5.copy(color = colors.gray700),
+            )
+            Row {
+                Text(
+                    text = stringResource(R.string.format_int, 1), // 임시로 1로 고정
+                    style = WalkieTheme.typography.head6.copy(color = colors.gray700),
+                )
+                Text(
+                    text = stringResource(R.string.character_count),
+                    style = WalkieTheme.typography.body2.copy(color = colors.gray500),
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CharacterDetailBottomSheet(
+    sheetState: SheetState,
+    character: WalkieCharacter?,
+    selectedCharacter: WalkieCharacter?,
+    onDismiss: () -> Unit,
+    onSelectPartner: (WalkieCharacter) -> Unit
+) {
+    val density = LocalDensity.current
+    val screenHeight = with(density) {
+        LocalConfiguration.current.screenHeightDp.dp
+    }
+
+    // 화면 상단에서 94dp만큼 떨어진 위치에서 시작하도록 계산
+    val sheetHeight = screenHeight - 94.dp
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        ModalBottomSheet(
+            onDismissRequest = onDismiss,
+            sheetState = sheetState,
+            tonalElevation = 24.dp,
+            containerColor = colors.white,
+            dragHandle = {
+                WalkieDragHandle()
+            },
+            contentColor = colors.white,
+            scrimColor = colors.blackOpacity60,
+            modifier = Modifier
+                .height(sheetHeight)
+                .align(Alignment.BottomCenter)
+        ) {
+            character?.let {
+                CharacterDetailContent(
+                    character = it,
+                    selectedCharacter = selectedCharacter,
+                    onSelectPartner = onSelectPartner
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun CharacterDetailContent(
+    character: WalkieCharacter,
+    selectedCharacter: WalkieCharacter?,
+    onSelectPartner: (WalkieCharacter) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(bottom = 30.dp, start = 16.dp, end = 16.dp)
+    ) {
+        CharacterDetailScrollableContent(
+            character = character,
+            modifier = Modifier
+                .fillMaxSize()
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+        )
+
+        Spacer(modifier = Modifier.height(34.dp))
+        CharacterSelectButton(
+            character = character,
+            isAlreadySelected = selectedCharacter?.id == character.id,
+            onSelectPartner = onSelectPartner
+        )
+    }
+}
+
+@Composable
+private fun CharacterDetailScrollableContent(
+    character: WalkieCharacter,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+    ) {
+        Image(
+            painter = painterResource(id = character.imageResource),
+            contentDescription = stringResource(id = character.nameResId),
+            modifier = Modifier.size(180.dp)
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = stringResource(id = character.nameResId),
+            style = WalkieTheme.typography.head3.copy(color = colors.gray700)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = stringResource(R.string.character_detail_wise_saying),
+            style = WalkieTheme.typography.body2.copy(color = colors.gray500),
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        CharacterInfoTags(character)
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        CharacterHistoryList()
+    }
+}
+
+@Composable
+private fun CharacterInfoTags(character: WalkieCharacter) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        TagMedium(
+            text = stringResource(character.rarity.rankStrResId),
+            textColor = character.rarity.getTextColor()
+        )
+        Row(
+            modifier = Modifier
+                .background(colors.gray100, shape = RoundedCornerShape(100.dp))
+                .padding(vertical = 8.dp, horizontal = 16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.format_int, 1), // 임시로 1로 고정
+                style = WalkieTheme.typography.head6.copy(color = colors.gray700),
+            )
+            Text(
+                text = stringResource(R.string.character_gain_count),
+                style = WalkieTheme.typography.body2.copy(color = colors.gray500),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CharacterHistoryList() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        repeat(10) {
+            CharacterHistoryItem()
+        }
+    }
+}
+
+@Composable
+private fun CharacterHistoryItem() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        color = colors.gray50
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp, horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .clip(CircleShape)
+                    .background(color = colors.blue300)
+            )
+
+            Text(
+                text = "서울시 서초구",
+                modifier = Modifier
+                    .padding(start = 4.dp)
+                    .weight(1f),
+                style = WalkieTheme.typography.body2.copy(color = colors.gray700)
+            )
+
+            Text(
+                text = "2025.01.13  부화",
+                style = WalkieTheme.typography.body2.copy(color = colors.gray500)
+            )
+        }
+    }
+}
+
+@Composable
+private fun CharacterSelectButton(
+    character: WalkieCharacter,
+    isAlreadySelected: Boolean,
+    onSelectPartner: (WalkieCharacter) -> Unit
+) {
+    val buttonText = if (isAlreadySelected) {
+        stringResource(R.string.character_already_selected)
+    } else {
+        stringResource(R.string.character_partner_select)
+    }
+
+    PrimaryButton(
+        text = buttonText,
+        enabled = !isAlreadySelected
+    ) {
+        if (!isAlreadySelected) {
+            onSelectPartner(character)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewScreenSizes
+@Composable
+@Preview(showBackground = true)
+fun PreviewCharacterDetailBottomSheet() {
+    WalkieTheme {
+        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        val characterFactory = CharacterFactory.getJellyfishCharacters()
+        val dummyCharacter = characterFactory[0]
+        val dummyCharacter2 = characterFactory[1]
+
+        CharacterDetailBottomSheet(
+            sheetState = sheetState,
+            character = dummyCharacter,
+            selectedCharacter = dummyCharacter2,
+            onDismiss = {},
+            onSelectPartner = {}
+        )
+    }
+}
+
+@PreviewScreenSizes
+@Composable
+@Preview
+private fun PreviewHatchingCharacterScreen() {
+    WalkieTheme {
+        HatchingCharacterScreen() {}
+    }
+}

--- a/feature/home/src/main/java/com/startup/home/character/model/WalkieCharacter.kt
+++ b/feature/home/src/main/java/com/startup/home/character/model/WalkieCharacter.kt
@@ -1,0 +1,122 @@
+package com.startup.home.character.model
+
+import com.startup.home.R
+import com.startup.home.egg.model.EggKind
+
+interface WalkieCharacter {
+    val id: String
+    val nameResId: Int
+    val imageResource: Int
+    val rarity: EggKind // 나중에 필요하다면, 별도 분리
+
+    fun getDescription(): Int
+}
+
+data class Jellyfish(
+    override val id: String,
+    override val nameResId: Int,
+    override val rarity: EggKind,
+    override val imageResource: Int
+) : WalkieCharacter {
+
+    override fun getDescription(): Int {
+        return R.string.character_jellyfish_description
+    }
+}
+
+data class Dino(
+    override val id: String,
+    override val nameResId: Int,
+    override val rarity: EggKind,
+    override val imageResource: Int
+) : WalkieCharacter {
+
+    override fun getDescription(): Int {
+        return R.string.character_dino_description
+    }
+}
+
+
+object CharacterFactory {
+    fun getJellyfishCharacters(): List<Jellyfish> {
+        return listOf(
+            Jellyfish(
+                "jellyfish_basic",
+                R.string.jellyfish_basic,
+                EggKind.Normal,
+                R.drawable.jelly_1
+            ),
+            Jellyfish("jellyfish_red", R.string.jellyfish_red, EggKind.Normal, R.drawable.jelly_2),
+            Jellyfish(
+                "jellyfish_green",
+                R.string.jellyfish_green,
+                EggKind.Normal,
+                R.drawable.jelly_3
+            ),
+            Jellyfish(
+                "jellyfish_purple",
+                R.string.jellyfish_purple,
+                EggKind.Normal,
+                R.drawable.jelly_4
+            ),
+            Jellyfish(
+                "jellyfish_pink",
+                R.string.jellyfish_pink,
+                EggKind.Normal,
+                R.drawable.jelly_5
+            ),
+            Jellyfish(
+                "jellyfish_rabbit",
+                R.string.jellyfish_rabbit,
+                EggKind.Rare,
+                R.drawable.jelly_6
+            ),
+            Jellyfish(
+                "jellyfish_starfish",
+                R.string.jellyfish_starfish,
+                EggKind.Rare,
+                R.drawable.jelly_7
+            ),
+            Jellyfish(
+                "jellyfish_electric_shock",
+                R.string.jellyfish_electric_shock,
+                EggKind.Epic,
+                R.drawable.jelly_8
+            ),
+            Jellyfish(
+                "jellyfish_strawberry_ricecake",
+                R.string.jellyfish_strawberry_ricecake,
+                EggKind.Epic,
+                R.drawable.jelly_9
+            ),
+            Jellyfish(
+                "jellyfish_space",
+                R.string.jellyfish_space,
+                EggKind.Legend,
+                R.drawable.jelly_10
+            )
+        )
+    }
+
+    fun getDinoCharacters(): List<Dino> {
+        return listOf(
+            Dino("dino_basic", R.string.dino_basic, EggKind.Normal, R.drawable.dino_1),
+            Dino("dino_red", R.string.dino_red, EggKind.Normal, R.drawable.dino_2),
+            Dino("dino_mint", R.string.dino_mint, EggKind.Normal, R.drawable.dino_3),
+            Dino("dino_purple", R.string.dino_purple, EggKind.Normal, R.drawable.dino_4),
+            Dino("dino_pink", R.string.dino_pink, EggKind.Normal, R.drawable.dino_5),
+            Dino("dino_reindeer", R.string.dino_reindeer, EggKind.Rare, R.drawable.dino_6),
+            Dino("dino_ness", R.string.dino_ness, EggKind.Rare, R.drawable.dino_7),
+            Dino("dino_pancake", R.string.dino_pancake, EggKind.Epic, R.drawable.dino_8),
+            Dino("dino_melon_soda", R.string.dino_melon_soda, EggKind.Epic, R.drawable.dino_9),
+            Dino("dino_dragon", R.string.dino_dragon, EggKind.Legend, R.drawable.dino_10)
+        )
+    }
+
+    fun getAllCharacters(): List<WalkieCharacter> {
+        val allCharacters = mutableListOf<WalkieCharacter>()
+        allCharacters.addAll(getJellyfishCharacters())
+        allCharacters.addAll(getDinoCharacters())
+        return allCharacters
+    }
+}


### PR DESCRIPTION
- Resolved : #36 

- 캐릭터 관련하여 모델 선언했습니다. 등급 관련해서는 eggkind 사용했습니다.
- 캐릭터 관련해서는 해파리, 다이노 자체가 10개 고정이라 Colum사용했어요
- 미획득 해파리 리소스가 색이 좀 달라서 디자이너분께 문의드려놨어요 

https://github.com/user-attachments/assets/fa934600-9cc7-4b76-8e6c-05810219df3d

