### PR TITLE
#120 홈에서 뒤로 가기 누를 때 바로 종료 되지 않도록 처리

### DIFF
--- a/core/design-system/src/main/java/com/startup/design_system/widget/toast/CustomToast.kt
+++ b/core/design-system/src/main/java/com/startup/design_system/widget/toast/CustomToast.kt
@@ -4,9 +4,11 @@ import android.widget.Toast
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -21,8 +23,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.PointerEventPass
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -38,22 +38,18 @@ private fun ToastOverlay(
 ) {
     var isVisible by remember { mutableStateOf(true) }
     if (isVisible) {
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .pointerInput(Unit) { // 터치 이벤트를 아래로 전달
-                    awaitPointerEventScope {
-                        while (true) {
-                            awaitPointerEvent(PointerEventPass.Initial)
-                        }
-                    }
-                },
-            contentAlignment = Alignment.Center
+                .padding(start = 16.dp, end = 16.dp, bottom = 86.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            Box(modifier = Modifier.weight(1F))
             Text(
                 modifier = Modifier
+                    .fillMaxWidth()
                     .background(WalkieTheme.colors.gray700, shape = RoundedCornerShape(12.dp))
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
                 text = message,
                 style = WalkieTheme.typography.body2,
                 color = Color.White,
@@ -79,20 +75,23 @@ private fun IconToastOverlay(
 ) {
     var isVisible by remember { mutableStateOf(true) }
     if (isVisible) {
-        Box(
+        Column(
             modifier = Modifier
-                .fillMaxSize(),
-            contentAlignment = Alignment.Center
+                .fillMaxSize()
+                .padding(start = 16.dp, end = 16.dp, bottom = 86.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            Box(modifier = Modifier.weight(1F))
             Row(
                 modifier = Modifier
                     .background(WalkieTheme.colors.gray700, shape = RoundedCornerShape(12.dp))
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(painter = painterResource(iconResId), tint = tint, contentDescription = null)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
+                    modifier = Modifier.fillMaxWidth(),
                     text = message,
                     style = WalkieTheme.typography.body2,
                     color = Color.White,

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -204,4 +204,5 @@
     <string name="desc_calendar_previous">이전 달</string>
     <string name="desc_calendar_after">이후 달</string>
     <string name="desc_calendar_select">캘린더로 일자 선택</string>
+    <string name="toast_home_back_press">한 번 더 누르면 워키가 종료됩니다</string>
 </resources>

--- a/feature/home/src/main/java/com/startup/home/MainBottomNavigationScreen.kt
+++ b/feature/home/src/main/java/com/startup/home/MainBottomNavigationScreen.kt
@@ -1,18 +1,27 @@
 package com.startup.home
 
+import android.app.Activity
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.startup.design_system.widget.toast.ShowToast
 import com.startup.home.main.HomeScreen
 import com.startup.home.main.HomeViewModel
 import com.startup.home.mypage.MyPageScreen
@@ -22,6 +31,7 @@ import com.startup.home.navigation.HomeScreenNav
 import com.startup.home.navigation.MainScreenNav
 import com.startup.home.navigation.MyPageScreenNav
 import com.startup.home.navigation.WalkieBottomNavigation
+import kotlinx.coroutines.delay
 
 @Composable
 fun MainBottomNavigationScreen(
@@ -31,6 +41,26 @@ fun MainBottomNavigationScreen(
     myPageViewModel: MyPageViewModel = hiltViewModel(),
 ) {
     val navHostController = rememberNavController()
+
+    val context = LocalContext.current
+    var backPressedOnce by remember { mutableStateOf(false) }
+    val canNavigateBack = navHostController.previousBackStackEntry != null
+
+    BackHandler(enabled = !canNavigateBack) {
+        if (backPressedOnce) {
+            (context as? Activity)?.finish()
+        } else {
+            backPressedOnce = true
+        }
+    }
+
+    // 2초 후 플래그 리셋
+    LaunchedEffect(backPressedOnce) {
+        if (backPressedOnce) {
+            delay(2000)
+            backPressedOnce = false
+        }
+    }
 
     LaunchedEffect(Unit) {
         myPageViewModel.event.collect {
@@ -131,5 +161,9 @@ fun MainBottomNavigationScreen(
                 onNavigationEvent.invoke(MainScreenNavigationEvent.MoveToSpotActivity)
             }
         )
+    }
+
+    if (backPressedOnce) {
+        ShowToast(stringResource(R.string.toast_home_back_press), 2_000) {}
     }
 }

--- a/feature/login/src/main/kotlin/com/startup/walkie/login/LoginScreen.kt
+++ b/feature/login/src/main/kotlin/com/startup/walkie/login/LoginScreen.kt
@@ -1,5 +1,7 @@
 package com.startup.walkie.login
 
+import android.app.Activity
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -22,20 +24,28 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.startup.design_system.widget.toast.ShowToast
 import com.startup.login.R
 import com.startup.ui.WalkieTheme
 import com.startup.ui.noRippleClickable
 import com.startup.walkie.login.model.LoginUiEvent
 import com.startup.walkie.login.model.OnBoardingPagerItem
+import kotlinx.coroutines.delay
 
 @Composable
 fun LoginScreen(uiEventSender: (LoginUiEvent) -> Unit) {
@@ -61,6 +71,25 @@ fun LoginScreen(uiEventSender: (LoginUiEvent) -> Unit) {
             description = stringResource(R.string.onboarding_4_sub_title)
         ),
     )
+
+    val context = LocalContext.current
+    var backPressedOnce by remember { mutableStateOf(false) }
+
+    BackHandler {
+        if (backPressedOnce) {
+            (context as? Activity)?.finish()
+        } else {
+            backPressedOnce = true
+        }
+    }
+
+    // 2초 후 플래그 리셋
+    LaunchedEffect(backPressedOnce) {
+        if (backPressedOnce) {
+            delay(2000)
+            backPressedOnce = false
+        }
+    }
 
     val configuration = LocalConfiguration.current
     val screenWidthDp = configuration.screenWidthDp
@@ -176,6 +205,10 @@ fun LoginScreen(uiEventSender: (LoginUiEvent) -> Unit) {
                 style = WalkieTheme.typography.body1.copy(color = WalkieTheme.colors.black)
             )
         }
+    }
+
+    if (backPressedOnce) {
+        ShowToast(stringResource(R.string.toast_home_back_press), 2_000) {}
     }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #120 

## 📝작업 내용
- 뒤로 가기 눌렀을 때 바로 종료 되지 않도록 처리했습니다.
- HomeScreen 에 안 넣은 이유는 Bottom Navi가 토스트 컴포넌트를 가려서 바깥으로 뺐어요!
- Toast 디자인이 언제 수정 된 것 같아서 해당 디자인도 맞췄습니다.
- 2초 이내로 뒤로 가기를 눌러야만 종료
- 마이 페이지 탭에서는 뒤로 가기 시 홈 탭으로 이동

## ✅체크 사항 (선택)
<img width="357" alt="image" src="https://github.com/user-attachments/assets/85aa7ca4-ca6e-4e8e-af1f-f376aed50383" />


## 📷스크린샷 (선택)

https://github.com/user-attachments/assets/00c59978-ca1e-45b1-9adc-7091745d963a



