### PR TITLE
#125 스켈레톤 뷰 구현 // 스팟 기록

### DIFF
--- a/core/common/src/main/java/com/startup/common/util/DateUtil.kt
+++ b/core/common/src/main/java/com/startup/common/util/DateUtil.kt
@@ -48,10 +48,15 @@ object DateUtil {
         return today.minusDays(today.dayOfWeek.value.toLong() % 7)
     }
 
-    fun matchWeekdayInSameWeekUntilToday(from: LocalDate, to: LocalDate, today: LocalDate = LocalDate.now()): LocalDate {
-        val fromDayOfWeek = from.dayOfWeek.value
-        val toStartOfWeek = to.minusDays((to.dayOfWeek.value - 1).toLong())
-        val aligned = toStartOfWeek.plusDays((fromDayOfWeek - 1).toLong())
+    fun matchWeekdayInSameWeekUntilToday(
+        from: LocalDate,
+        to: LocalDate,
+        today: LocalDate = LocalDate.now()
+    ): LocalDate {
+        val fromDayOfWeek = from.dayOfWeek.value % 7
+        val toStartOfWeek = getStartOfWeek(to)
+        Printer.e("LMH", "from $fromDayOfWeek startWeek $toStartOfWeek")
+        val aligned = toStartOfWeek.plusDays((fromDayOfWeek).toLong())
         return if (aligned.isAfter(today)) today else aligned
     }
 

--- a/feature/home/src/main/java/com/startup/home/spot/WalkieWeekCalendar.kt
+++ b/feature/home/src/main/java/com/startup/home/spot/WalkieWeekCalendar.kt
@@ -39,7 +39,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
-
 @Composable
 internal fun WalkieWeekCalendar(
     selectDate: CalendarModel,
@@ -50,7 +49,7 @@ internal fun WalkieWeekCalendar(
 ) {
     val latestSelectDate by rememberUpdatedState(newValue = selectDate)
     val today = LocalDate.now()
-    val currentWeekFirstDay = getStartOfWeek(selectDate.date)
+    val currentWeekFirstDay = getStartOfWeek(latestSelectDate.date)
     val pagerState = rememberPagerState(
         initialPage = Int.MAX_VALUE,
         pageCount = { Int.MAX_VALUE }
@@ -75,10 +74,12 @@ internal fun WalkieWeekCalendar(
             .map { (page, _) -> page }
             .distinctUntilChanged()
             .collect { page ->
-                Printer.e("LMH", "PAGE! $page, ${latestSelectDate.isSpecificDate}")
+                Printer.e("LMH", "PAGE! $page, $latestSelectDate")
                 if (!latestSelectDate.isSpecificDate) {
                     val weekChangeOfToDay =
-                        today.plusWeeks((page.toLong() + 1) - Int.MAX_VALUE.toLong())
+                        today.plusWeeks((page.toLong() + 1) - (Int.MAX_VALUE.toLong()))
+
+
                     val latestWeekFirstDay = getStartOfWeek(latestSelectDate.date)
                     if (!latestWeekFirstDay.isEqual(getStartOfWeek(weekChangeOfToDay))) {
                         val alignWeekDate = matchWeekdayInSameWeekUntilToday(
@@ -104,7 +105,7 @@ internal fun WalkieWeekCalendar(
         WeeklyView(
             startOfWeek = startOfWeek,
             today = today,
-            selectedDate = selectDate.date,
+            selectedDate = latestSelectDate.date,
             events = events,
             onDateSelected = { date ->
                 onDateSelected(date)

--- a/feature/home/src/main/java/com/startup/home/spot/model/SpotArchiveContract.kt
+++ b/feature/home/src/main/java/com/startup/home/spot/model/SpotArchiveContract.kt
@@ -2,25 +2,21 @@ package com.startup.home.spot.model
 
 import com.startup.common.base.BaseState
 import com.startup.common.base.UiEvent
+import com.startup.common.util.BaseUiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.update
 import java.time.LocalDate
 
 interface SpotArchiveViewState : BaseState {
     val currentSelectedDate: StateFlow<CalendarModel>
-    val eventList: StateFlow<Map<String, List<ReviewModel>>>
+    val eventList: StateFlow<Map<String, BaseUiState<List<ReviewModel>>>>
 }
 
 class SpotArchiveViewStateImpl : SpotArchiveViewState {
     override val currentSelectedDate: MutableStateFlow<CalendarModel> =
         MutableStateFlow(CalendarModel(LocalDate.now(), isSpecificDate = true))
-    override val eventList: MutableStateFlow<Map<String, List<ReviewModel>>> =
+    override val eventList: MutableStateFlow<Map<String, BaseUiState<List<ReviewModel>>>> =
         MutableStateFlow(mapOf())
-
-    fun clearEventList() {
-        eventList.update { mapOf() }
-    }
 }
 
 sealed interface SpotArchiveUiEvent : UiEvent {


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #125 

## 📝작업 내용
- 스팟 기록 Skeleton 적용했습니다!

## ✅체크 사항 (선택)
- 불러오려는 주의 시작요일을 key 로 fetch 를 하기에 그거 기반으로 onStart 에서 미리 BaseUiState isShowShimmer = true 로 넣어둔 후 받아온 데이터는 isShowShimmer = false 로 컨버팅하여 업데이트 하고 있습니다. 따라서 이미 불러온 데이터는 이론상 shimmer 가 작동하지 않습니다.
- 불러오려는 주의 리스트 제외로도 empty 로 데이터가 안 오는 데이터가 있을 것이고 데이터를 받은 후에는 shimmer 상태는 전체 다 false 로 하는게 맞는 것 같아서 filtering 하여 false 로 업데이트하는 구문도 추가 되었습니다! UseCase 에 넣었어야했나 싶긴해요..
- DateUtil의 matchWeekdayInSameWeekUntilToday 함수가 요일만 그대로인 주를 반환하는 함수인데, 전주의 요일을 들고 오는 케이스가 있어서 해당 부분 수정 했습니다. toStartOfWeek 부분이 전주를 가리켜서 요일의 시작 계산하는 부분을 수정했습니다!

## 📷스크린샷 (선택)

https://github.com/user-attachments/assets/51cf8d76-c288-4785-a3df-f4ccbc4be74d


