### PR TITLE
#145 회원가입 시 카카오 닉네임 가져오기

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -68,6 +68,17 @@
 # Retrofit does reflection on method and parameter annotations.
 -keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
 
+# 모든 object를 자동 보호
+-keepclassmembers class ** {
+    static ** INSTANCE;
+}
+
+-keepclassmembers class ** {
+    *** get*();
+    *** is*();
+    *** set*(***);
+}
+
 # Gson
 -keep class com.google.gson.** { *; }
 -keepclassmembers class * {
@@ -100,6 +111,9 @@
 -keep class com.startup.common.provider.** { *; }
 -keep class com.startup.common.di.** { *; }
 -keep class com.startup.common.util.** { *; }
+-keep class com.startup.common.event.** { *; }
+-keep class com.startup.common.extension.** { *; }
+
 
 # Login
 -keep class com.startup.login.navigation.** { *; }
@@ -112,6 +126,7 @@
 # Step Counter
 -keep class com.startup.stepcounter.di.** { *; }
 -keep class com.startup.stepcounter.navigation.** { *; }
+-keep class com.startup.stepcounter.service.** { *; }
 
 # Design-System
 -keep class com.startup.design_system.ui.** { *; }
@@ -136,6 +151,11 @@
 -keep class **_Factory { *; }
 -keep class **_HiltComponents* { *; }
 
+# 모든 Hilt EntryPoint 인터페이스 보호 (범용적으로 추가 가능)
+-keep class dagger.hilt.internal.GeneratedComponent { *; }
+-keep class dagger.hilt.android.internal.lifecycle.HiltViewModelFactory { *; }
+-keep class dagger.hilt.android.internal.managers.* { *; }
+-keep class dagger.hilt.android.internal.modules.* { *; }
 -keep class **.HiltWrapper_* { *; }
 -keep @dagger.Module class * { *; }
 -keep @dagger.Provides class * { *; }

--- a/core/common/src/main/java/com/startup/common/di/ProviderModule.kt
+++ b/core/common/src/main/java/com/startup/common/di/ProviderModule.kt
@@ -2,6 +2,8 @@ package com.startup.common.di
 
 import com.startup.common.provider.LocationProvider
 import com.startup.common.provider.LocationProviderImpl
+import com.startup.common.util.ResourceProvider
+import com.startup.common.util.ResourceProviderImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -15,4 +17,8 @@ abstract class ProviderModule {
     @Singleton
     @Binds
     abstract fun bindsStepDataStore(stepDataStore: LocationProviderImpl): LocationProvider
+
+    @Singleton
+    @Binds
+    abstract fun bindsToResourceProvider(resourceProviderImpl: ResourceProviderImpl): ResourceProvider
 }

--- a/core/common/src/main/java/com/startup/common/util/CustomExceptions.kt
+++ b/core/common/src/main/java/com/startup/common/util/CustomExceptions.kt
@@ -30,6 +30,7 @@ class ResponseErrorException(
 class UserAuthNotFoundException(
     override val message: String? = null,
     val providerToken: String,
+    val nickName: String?,
     val code: Int? = null
 ) : Exception(message), WalkieException
 

--- a/core/common/src/main/java/com/startup/common/util/ResourceProvider.kt
+++ b/core/common/src/main/java/com/startup/common/util/ResourceProvider.kt
@@ -1,15 +1,5 @@
 package com.startup.common.util
 
-import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
-import javax.inject.Inject
-import javax.inject.Singleton
-
-@Singleton
-class ResourceProvider @Inject constructor(
-    @ApplicationContext private val context: Context,
-) {
-    fun getString(resId: Int): String {
-        return context.getString(resId)
-    }
+interface ResourceProvider {
+    fun getString(resId: Int): String
 }

--- a/core/common/src/main/java/com/startup/common/util/ResourceProviderImpl.kt
+++ b/core/common/src/main/java/com/startup/common/util/ResourceProviderImpl.kt
@@ -1,0 +1,15 @@
+package com.startup.common.util
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ResourceProviderImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ResourceProvider {
+    override fun getString(resId: Int): String {
+        return context.getString(resId)
+    }
+}

--- a/core/common/src/main/java/com/startup/common/util/StringExtension.kt
+++ b/core/common/src/main/java/com/startup/common/util/StringExtension.kt
@@ -1,3 +1,5 @@
+package com.startup.common.util
+
 import android.graphics.Typeface
 import android.text.Html
 import android.text.style.ForegroundColorSpan

--- a/core/data/src/main/java/com/startup/data/remote/datasourceimpl/AuthDataSourceImpl.kt
+++ b/core/data/src/main/java/com/startup/data/remote/datasourceimpl/AuthDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.startup.data.remote.datasourceimpl
 
 import androidx.datastore.preferences.core.Preferences
 import com.startup.common.util.KakaoAuthFailException
+import com.startup.common.util.Printer
 import com.startup.common.util.ResponseErrorException
 import com.startup.common.util.UserAuthNotFoundException
 import com.startup.data.datasource.AuthDataSource
@@ -57,6 +58,7 @@ internal class AuthDataSourceImpl @Inject constructor(
             if (item.data != null && item.data.accessToken == null) {
                 throw UserAuthNotFoundException(
                     message = "계정 없음",
+                    nickName = kakaoLoginClient.me().getOrNull()?.kakaoAccount?.profile?.nickname,
                     providerToken = it
                 )
             }

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="play_this_egg">이 알과 같이 걷기</string>
     <string name="playing_this_egg">같이 걷는 중…</string>
 
+    <string name="onboarding_nick_name_default_placeholder">닉네임</string>
     <string name="onboarding_nick_name_title">워키에서 사용할\n닉네임을 지어주세요</string>
     <string name="onboarding_nick_name_placeholder">워키에서 사용할\n닉네임을 지어주세요</string>
     <string name="onboarding_nick_name_apply">완료</string>

--- a/feature/home/src/main/java/com/startup/home/main/HomeScreen.kt
+++ b/feature/home/src/main/java/com/startup/home/main/HomeScreen.kt
@@ -69,8 +69,8 @@ import com.startup.home.egg.model.MyEggModel
 import com.startup.home.menu.HistoryItemModel
 import com.startup.design_system.ui.WalkieTheme
 import com.startup.design_system.ui.noRippleClickable
-import withBold
-import withUnderline
+import com.startup.common.util.withBold
+import com.startup.common.util.withUnderline
 
 data class HomePermissionState(
     val showActivityRecognitionAlert: Boolean = false,

--- a/feature/home/src/main/java/com/startup/home/mypage/MyPageScreen.kt
+++ b/feature/home/src/main/java/com/startup/home/mypage/MyPageScreen.kt
@@ -43,7 +43,7 @@ import com.startup.home.R
 import com.startup.home.mypage.model.MyInfoViewState
 import com.startup.design_system.ui.WalkieTheme
 import com.startup.design_system.ui.noRippleClickable
-import withColor
+import com.startup.common.util.withColor
 
 @Composable
 fun MyPageScreen(

--- a/feature/login/src/main/kotlin/com/startup/login/login/NickNameSettingScreen.kt
+++ b/feature/login/src/main/kotlin/com/startup/login/login/NickNameSettingScreen.kt
@@ -35,7 +35,8 @@ import com.startup.design_system.ui.noRippleClickable
 import com.startup.login.login.model.NickNameSettingEvent
 import com.startup.login.login.model.NickNameViewState
 import com.startup.login.login.model.NickNameViewStateImpl
-import hasSpecialCharacters
+import com.startup.common.util.hasSpecialCharacters
+import kotlinx.coroutines.flow.MutableStateFlow
 
 @Composable
 fun NickNameSettingScreen(
@@ -183,6 +184,6 @@ fun NickNameSettingScreen(
 @Preview(showBackground = true)
 fun PreviewNickNameSettingScreen() {
     WalkieTheme {
-        NickNameSettingScreen(NickNameViewStateImpl(), {})
+        NickNameSettingScreen(NickNameViewStateImpl(placeHolder = MutableStateFlow("")), {})
     }
 }

--- a/feature/login/src/main/kotlin/com/startup/login/login/model/LoginContract.kt
+++ b/feature/login/src/main/kotlin/com/startup/login/login/model/LoginContract.kt
@@ -42,12 +42,11 @@ interface NickNameViewState : BaseState {
     val providerToken: StateFlow<String?>
 }
 
-class NickNameViewStateImpl : NickNameViewState {
+class NickNameViewStateImpl(override val placeHolder: MutableStateFlow<String>) : NickNameViewState {
     override val nickName: MutableStateFlow<TextFieldValue> = MutableStateFlow(
         TextFieldValue(
             ""
         )
     )
-    override val placeHolder: MutableStateFlow<String> = MutableStateFlow("닉네임")
     override val providerToken: MutableStateFlow<String?> = MutableStateFlow(null)
 }

--- a/feature/stepcounter/src/main/java/com/startup/stepcounter/di/StepCounterServiceModule.kt
+++ b/feature/stepcounter/src/main/java/com/startup/stepcounter/di/StepCounterServiceModule.kt
@@ -1,4 +1,4 @@
-package com.startup.stepcounter
+package com.startup.stepcounter.di
 
 import com.startup.stepcounter.service.StepCounterService
 import com.startup.stepcounter.service.StepCounterServiceImpl

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
 
 android {
     namespace = "com.startup.navigation"
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #145 

## 📝작업 내용
- 회원 가입 창으로 이동을 하는 커스텀 Exception Throw 할 때 nickName 도 넣어주도록 처리했습니다. (UserAuthNotFoundException)
- 문제는.. 제 카카오 계정은 이미 가입 돼 있어서 일단 로그로 확인했어요 ㅎ,ㅎ 닉네임 없으면 setting 안 하고 default 가 보이도록 처리했습니다.
- ResourceProvider 추상화 처리했습니다.

## ✅체크 사항 (선택)
- 릴리즈 빌드로 카카오 로그인이 안 되는데,,, 뭐 따로 설정해야할게 있을까요??
- 앱 전달 시 내부 테스트, 비공개 테스트로 앱 미리 올리는거 어떤가요?? @IslandofDream 

## 📷스크린샷 (선택)
<img width="903" alt="image" src="https://github.com/user-attachments/assets/ab6c1239-bd10-42c4-b6e5-a3f9abe2e738" />

