### PR TITLE
#152 로그아웃 / 회원 탈퇴 API 연동

### DIFF
--- a/core/data/src/main/java/com/startup/data/remote/datasourceimpl/AuthDataSourceImpl.kt
+++ b/core/data/src/main/java/com/startup/data/remote/datasourceimpl/AuthDataSourceImpl.kt
@@ -2,7 +2,6 @@ package com.startup.data.remote.datasourceimpl
 
 import androidx.datastore.preferences.core.Preferences
 import com.startup.common.util.KakaoAuthFailException
-import com.startup.common.util.Printer
 import com.startup.common.util.ResponseErrorException
 import com.startup.common.util.UserAuthNotFoundException
 import com.startup.data.datasource.AuthDataSource
@@ -88,8 +87,8 @@ internal class AuthDataSourceImpl @Inject constructor(
     override fun logOut(): Flow<Unit> = flow {
         handleExceptionIfNeed {
             kakaoLoginClient.logout()
-            emitRemote(memberService.logout())
             logoutManager.logout()
+            emitRemote(memberService.logoutService())
         }
     }
 
@@ -114,5 +113,6 @@ internal class AuthDataSourceImpl @Inject constructor(
         Unit
     }
 
-    override fun getAccessToken(): Flow<String> = tokenDataStoreProvider.getFlowValue(accessTokenKey)
+    override fun getAccessToken(): Flow<String> =
+        tokenDataStoreProvider.getFlowValue(accessTokenKey)
 }

--- a/core/data/src/main/java/com/startup/data/remote/service/MemberService.kt
+++ b/core/data/src/main/java/com/startup/data/remote/service/MemberService.kt
@@ -1,17 +1,18 @@
 package com.startup.data.remote.service
 
 import com.startup.data.remote.BaseResponse
-import com.startup.data.remote.dto.response.character.CharacterDto
 import com.startup.data.remote.dto.request.character.CharacterIdRequest
-import com.startup.data.remote.dto.response.egg.EggDto
 import com.startup.data.remote.dto.request.egg.WalkingEggRequest
 import com.startup.data.remote.dto.request.member.MemberNickNameRequest
+import com.startup.data.remote.dto.response.character.CharacterDto
+import com.startup.data.remote.dto.response.egg.EggDto
 import com.startup.data.remote.dto.response.member.GetUserInfoResponse
 import com.startup.data.remote.dto.response.member.IsPublicDto
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
+import retrofit2.http.POST
 
 internal interface MemberService {
     /** 내 정보 조회하기 */
@@ -27,8 +28,8 @@ internal interface MemberService {
     suspend fun withdrawalService(): BaseResponse<Unit>
 
     /** 로그 아웃 하기 */
-    @DELETE("api/v1/members/logout")
-    suspend fun logout(): BaseResponse<Unit>
+    @POST("api/v1/auth/logout")
+    suspend fun logoutService(): BaseResponse<Unit>
 
     /** 같이 걷는 알 변경 API */
     @PATCH("api/v1/members/eggs/play")
@@ -50,7 +51,7 @@ internal interface MemberService {
     @PATCH("api/v1/members/profile/visibility")
     suspend fun changeUserProfileVisibility(): BaseResponse<IsPublicDto>
 
-    /* 사용자가 기록한 스팟의 갯수 조회 */
+    /** 사용자가 기록한 스팟의 갯수 조회 **/
     @GET("api/v1/members/recorded-spot")
     suspend fun getRecordedSpotCount(): BaseResponse<Int>
 

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -213,4 +213,5 @@
     <string name="desc_calendar_after">이후 달</string>
     <string name="desc_calendar_select">캘린더로 일자 선택</string>
     <string name="toast_home_back_press">한 번 더 누르면 워키가 종료됩니다</string>
+    <string name="toast_common_error">일시적 오류가 발생했습니다. 잠시후 다시 시도해주세요.</string>
 </resources>

--- a/feature/home/src/main/java/com/startup/home/MainContract.kt
+++ b/feature/home/src/main/java/com/startup/home/MainContract.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
 import com.startup.common.base.BaseEvent
 import com.startup.common.base.ScreenNavigationEvent
-import com.startup.common.base.UiEvent
 
 sealed interface MainScreenNavigationEvent : ScreenNavigationEvent {
     data object MoveToLoginActivity : MainScreenNavigationEvent
@@ -13,11 +12,12 @@ sealed interface MainScreenNavigationEvent : ScreenNavigationEvent {
         val intent: Intent.() -> Intent
     ) : MainScreenNavigationEvent
 
-    data class MoveToSpotActivity(val launcher : ActivityResultLauncher<Intent>) : MainScreenNavigationEvent
+    data class MoveToSpotActivity(val launcher: ActivityResultLauncher<Intent>) :
+        MainScreenNavigationEvent
 }
 
 sealed interface HomeScreenViewModelEvent : BaseEvent {
-    data object RefreshReviewList: HomeScreenViewModelEvent
+    data object RefreshReviewList : HomeScreenViewModelEvent
 }
 
 sealed interface HomeScreenNavigationEvent : ScreenNavigationEvent {
@@ -39,7 +39,6 @@ sealed interface MyPageScreenNavigationEvent : ScreenNavigationEvent {
     data object MoveToNotification : MyPageScreenNavigationEvent
 }
 
-
-sealed interface MyPageUiEvent : UiEvent {
-    data object OnClickLogout : MyPageUiEvent
+sealed interface ErrorToastEvent : BaseEvent {
+    data class ShowToast(val messageResId: Int = R.string.toast_common_error) : ErrorToastEvent
 }

--- a/feature/home/src/main/java/com/startup/home/mypage/MyPageViewModel.kt
+++ b/feature/home/src/main/java/com/startup/home/mypage/MyPageViewModel.kt
@@ -8,12 +8,14 @@ import com.startup.domain.usecase.GetArriveSpotNotiEnabled
 import com.startup.domain.usecase.GetEggHatchedNotiEnabled
 import com.startup.domain.usecase.GetMyData
 import com.startup.domain.usecase.GetTodayStepNotiEnabled
-import com.startup.domain.usecase.LocalLogout
+import com.startup.domain.usecase.Logout
 import com.startup.domain.usecase.Unlink
 import com.startup.domain.usecase.UpdateArriveSpotNotiEnabled
 import com.startup.domain.usecase.UpdateEggHatchedNotiEnabled
 import com.startup.domain.usecase.UpdateTodayStepNotiEnabled
+import com.startup.home.ErrorToastEvent
 import com.startup.home.MainScreenNavigationEvent
+import com.startup.home.R
 import com.startup.home.mypage.model.MyInfoViewModelEvent
 import com.startup.home.mypage.model.MyInfoViewState
 import com.startup.home.mypage.model.MyInfoViewStateImpl
@@ -40,7 +42,7 @@ class MyPageViewModel @Inject constructor(
     private val updateEggHatchedNotiEnabled: UpdateEggHatchedNotiEnabled,
     private val updateTodayStepNotiEnabled: UpdateTodayStepNotiEnabled,
     private val unlink: Unlink,
-    private val localLogout: LocalLogout
+    private val logout: Logout
 ) : BaseViewModel() {
     @OptIn(ExperimentalCoroutinesApi::class)
     private val _state: MyInfoViewStateImpl = MyInfoViewStateImpl(
@@ -97,18 +99,24 @@ class MyPageViewModel @Inject constructor(
     fun unLink() {
         unlink
             .invoke(Unit)
-            .onEach { notifyEvent(MainScreenNavigationEvent.MoveToLoginActivity) }
-            .catch { }
+            .onEach {
+                notifyEvent(MainScreenNavigationEvent.MoveToLoginActivity)
+            }
+            .catch {
+                notifyEvent(ErrorToastEvent.ShowToast(R.string.toast_common_error))
+            }
             .launchIn(viewModelScope)
     }
 
     fun logout() {
-        localLogout
+        logout
             .invoke(Unit)
             .onEach {
                 notifyEvent(MainScreenNavigationEvent.MoveToLoginActivity)
             }
-            .catch { }
+            .catch {
+                notifyEvent(MainScreenNavigationEvent.MoveToLoginActivity)
+            }
             .launchIn(viewModelScope)
     }
 }

--- a/feature/home/src/main/java/com/startup/home/navigation/MyPageNavigationGraph.kt
+++ b/feature/home/src/main/java/com/startup/home/navigation/MyPageNavigationGraph.kt
@@ -12,7 +12,13 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -21,7 +27,11 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.startup.common.base.NavigationEvent
+import com.startup.design_system.ui.WalkieTheme
+import com.startup.design_system.widget.toast.ShowToast
+import com.startup.home.ErrorToastEvent
 import com.startup.home.MainScreenNavigationEvent
+import com.startup.home.R
 import com.startup.home.mypage.MyInfoScreen
 import com.startup.home.mypage.MyPageViewModel
 import com.startup.home.mypage.PersonalInfoPolicyScreen
@@ -33,7 +43,6 @@ import com.startup.home.mypage.model.MyInfoUIEvent
 import com.startup.home.mypage.model.PushSettingUIEvent
 import com.startup.home.mypage.model.UnlinkUiEvent
 import com.startup.home.notification.NotificationListScreen
-import com.startup.design_system.ui.WalkieTheme
 
 @Composable
 fun MyPageNavigationGraph(
@@ -45,12 +54,19 @@ fun MyPageNavigationGraph(
     val navController = rememberNavController()
     val snackBarHostState = SnackbarHostState()
     // 홈화면(각각의 NavGraph), 지도화면(각각의 NavGraph), 마이페이지 화면(각각의 NavGraph)
+    var showErrorToast by remember { mutableStateOf(false) }
+    var errorMessageResId by remember { mutableIntStateOf(R.string.toast_common_error) }
 
     LaunchedEffect(Unit) {
         myPageViewModel.event.collect {
             when (it) {
                 MainScreenNavigationEvent.MoveToLoginActivity -> {
                     onNavigationEvent.invoke(MainScreenNavigationEvent.MoveToLoginActivity)
+                }
+
+                is ErrorToastEvent.ShowToast -> {
+                    errorMessageResId = it.messageResId
+                    showErrorToast = true
                 }
 
                 else -> {}
@@ -157,7 +173,6 @@ fun MyPageNavigationGraph(
                         uiEventSender = {
                             when (it) {
                                 UnlinkUiEvent.UnlinkWalkie -> {
-                                    // TODO
                                     myPageViewModel.unLink()
                                 }
                             }
@@ -173,6 +188,12 @@ fun MyPageNavigationGraph(
                     })
                 }
             }
+        }
+    }
+
+    if (showErrorToast) {
+        ShowToast(stringResource(errorMessageResId), 2_000) {
+            showErrorToast = false
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #152 

## 📝작업 내용
- 로그아웃 / 회원탈퇴 API 연동하였습니다. 

## ✅체크 사항 (선택)
- 로그아웃 API가 실제로는 호출이 안되고 있어서 명세에 맞춰서 수정 및 동작 추가했습니다!
- 로그아웃, 회원가입은 적어도 에러 안내라도 되어야 할 거 같아서 에러 토스트메시지 관련 동작 추가하였습니다.
- 회원탈퇴 API 배포 이후 동작 테스트만 하면 draft 풀고 PR 코드리뷰 요청 드릴께요 ( 5/4기준 )

## 📷스크린샷 (선택)
- 에러 토스트 동작

https://github.com/user-attachments/assets/4aa4280a-cf07-4c3b-b2d2-c2c58fd95812