### PR TITLE
#179 마이페이지 스켈레톤 처리

### DIFF
--- a/core/domain/src/main/java/com/startup/domain/model/member/UserInfo.kt
+++ b/core/domain/src/main/java/com/startup/domain/model/member/UserInfo.kt
@@ -16,4 +16,20 @@ data class UserInfo(
     val recordedSpot: Int,
     val userCharacterId: Long,
     val eggId: Long
-)
+) {
+    companion object {
+        fun ofEmpty(): UserInfo = UserInfo(
+            memberId = -1,
+            memberEmail = "",
+            memberNickName = "",
+            isPublic = false,
+            memberTier = "",
+            providerId = "",
+            provider = "",
+            exploredSpot = 0,
+            recordedSpot = 0,
+            userCharacterId = -1,
+            eggId = -1
+        )
+    }
+}

--- a/feature/home/src/main/java/com/startup/home/mypage/MyPageContract.kt
+++ b/feature/home/src/main/java/com/startup/home/mypage/MyPageContract.kt
@@ -2,6 +2,7 @@ package com.startup.home.mypage
 
 import com.startup.common.base.BaseEvent
 import com.startup.common.base.BaseState
+import com.startup.common.base.BaseUiState
 import com.startup.common.base.ScreenNavigationEvent
 import com.startup.common.base.UiEvent
 import com.startup.domain.model.member.UserInfo
@@ -14,7 +15,7 @@ interface MyInfoViewState : BaseState {
     val isNotificationEnabledSpotArrive: StateFlow<Boolean>
     val isNotificationEnabledEggHatched: StateFlow<Boolean>
     val isNotificationEnabledTodayStep: StateFlow<Boolean>
-    val userInfo : StateFlow<UserInfo?>
+    val userInfo : StateFlow<BaseUiState<UserInfo>>
 }
 
 interface NoticeViewState : BaseState {
@@ -31,7 +32,7 @@ class MyInfoViewStateImpl(
     override val isNotificationEnabledSpotArrive: StateFlow<Boolean>,
     override val isNotificationEnabledEggHatched: StateFlow<Boolean>,
     override val isNotificationEnabledTodayStep: StateFlow<Boolean>,
-    override val userInfo: StateFlow<UserInfo?>
+    override val userInfo: StateFlow<BaseUiState<UserInfo>>
 ) : MyInfoViewState
 
 sealed interface MyInfoUIEvent : UiEvent {

--- a/feature/home/src/main/java/com/startup/home/mypage/MyPageViewModel.kt
+++ b/feature/home/src/main/java/com/startup/home/mypage/MyPageViewModel.kt
@@ -1,18 +1,20 @@
 package com.startup.home.mypage
 
 import androidx.lifecycle.viewModelScope
+import com.startup.common.base.BaseUiState
 import com.startup.common.base.BaseViewModel
 import com.startup.common.util.Printer
-import com.startup.domain.usecase.profile.ChangeUserProfileVisibility
-import com.startup.domain.usecase.notification.GetArriveSpotNotiEnabled
-import com.startup.domain.usecase.notification.GetEggHatchedNotiEnabled
-import com.startup.domain.usecase.profile.GetMyData
-import com.startup.domain.usecase.notification.GetTodayStepNotiEnabled
+import com.startup.domain.model.member.UserInfo
 import com.startup.domain.usecase.auth.Logout
 import com.startup.domain.usecase.auth.Unlink
+import com.startup.domain.usecase.notification.GetArriveSpotNotiEnabled
+import com.startup.domain.usecase.notification.GetEggHatchedNotiEnabled
+import com.startup.domain.usecase.notification.GetTodayStepNotiEnabled
 import com.startup.domain.usecase.notification.UpdateArriveSpotNotiEnabled
 import com.startup.domain.usecase.notification.UpdateEggHatchedNotiEnabled
 import com.startup.domain.usecase.notification.UpdateTodayStepNotiEnabled
+import com.startup.domain.usecase.profile.ChangeUserProfileVisibility
+import com.startup.domain.usecase.profile.GetMyData
 import com.startup.home.ErrorToastEvent
 import com.startup.home.MainScreenNavigationEvent
 import com.startup.home.R
@@ -62,8 +64,17 @@ class MyPageViewModel @Inject constructor(
             .stateInViewModel(false),
         userInfo = getMyData
             .invoke(Unit)
-            .catch { }
-            .stateInViewModel(null)
+            .map {
+                BaseUiState(isShowShimmer = false, data = it) }
+            .catch {
+                emit(BaseUiState(isShowShimmer = false, data = UserInfo.ofEmpty()))
+            }
+            .stateInViewModel(
+                initialValue = BaseUiState(
+                    isShowShimmer = true,
+                    data = UserInfo.ofEmpty()
+                )
+            )
     )
     override val state: MyInfoViewState get() = _state
 

--- a/feature/home/src/main/java/com/startup/home/mypage/screen/MyInfoScreen.kt
+++ b/feature/home/src/main/java/com/startup/home/mypage/screen/MyInfoScreen.kt
@@ -22,17 +22,16 @@ import com.startup.design_system.widget.actionbar.PageActionBarType
 import com.startup.design_system.widget.toggle.ToggleWithText
 import com.startup.home.R
 import com.startup.home.mypage.MyInfoUIEvent
-import com.startup.home.mypage.MyInfoViewState
-import com.startup.home.mypage.MyInfoViewStateImpl
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun MyInfoScreen(
-    viewState: MyInfoViewState,
+    isProfileAccessFlow: StateFlow<Boolean>,
     uiEventSender: (MyInfoUIEvent) -> Unit,
     onNavigationEvent: (NavigationEvent) -> Unit
 ) {
-    val isProfileAccess by viewState.isProfileAccess.collectAsState()
+    val isProfileAccess by isProfileAccessFlow.collectAsState()
     Printer.e("LMH", "isProfileAccess $isProfileAccess")
     Column(
         modifier = Modifier
@@ -75,13 +74,7 @@ fun MyInfoScreen(
 private fun PreviewMyInfoScreen() {
     WalkieTheme {
         MyInfoScreen(
-            viewState = MyInfoViewStateImpl(
-                isNotificationEnabledEggHatched = MutableStateFlow(false),
-                isProfileAccess = MutableStateFlow(false),
-                isNotificationEnabledTodayStep = MutableStateFlow(false),
-                isNotificationEnabledSpotArrive = MutableStateFlow(false),
-                userInfo = MutableStateFlow(null)
-            ),
+            MutableStateFlow(false),
             {}, {}
         )
     }

--- a/feature/home/src/main/java/com/startup/home/mypage/screen/PushSettingScreen.kt
+++ b/feature/home/src/main/java/com/startup/home/mypage/screen/PushSettingScreen.kt
@@ -20,20 +20,20 @@ import com.startup.design_system.widget.actionbar.PageActionBar
 import com.startup.design_system.widget.actionbar.PageActionBarType
 import com.startup.design_system.widget.toggle.ToggleWithText
 import com.startup.home.R
-import com.startup.home.mypage.MyInfoViewState
-import com.startup.home.mypage.MyInfoViewStateImpl
 import com.startup.home.mypage.PushSettingUIEvent
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun PushSettingScreen(
-    viewState: MyInfoViewState,
+    isNotificationEnabledEggHatchedFlow: StateFlow<Boolean>,
+    isNotificationEnabledSpotArriveFlow: StateFlow<Boolean>,
     uiEventSender: (PushSettingUIEvent) -> Unit,
     onNavigationEvent: (NavigationEvent) -> Unit
 ) {
     /*val isTodayStepNotiEnabled by viewState.isNotificationEnabledTodayStep.collectAsState()*/
-    val isArriveSpotNotiEnabled by viewState.isNotificationEnabledSpotArrive.collectAsState()
-    val isEggHatchedNotiEnabled by viewState.isNotificationEnabledEggHatched.collectAsState()
+    val isArriveSpotNotiEnabled by isNotificationEnabledEggHatchedFlow.collectAsState()
+    val isEggHatchedNotiEnabled by isNotificationEnabledSpotArriveFlow.collectAsState()
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -84,12 +84,7 @@ fun PushSettingScreen(
 private fun PreviewPushSettingScreen() {
     WalkieTheme {
         PushSettingScreen(
-            MyInfoViewStateImpl(
-                isNotificationEnabledEggHatched = MutableStateFlow(false),
-                isProfileAccess = MutableStateFlow(false),
-                isNotificationEnabledTodayStep = MutableStateFlow(false),
-                isNotificationEnabledSpotArrive = MutableStateFlow(false),
-                userInfo = MutableStateFlow(null)
-            ), {}, {})
+            MutableStateFlow(false),
+            MutableStateFlow(false), {}, {})
     }
 }

--- a/feature/home/src/main/java/com/startup/home/navigation/MyPageNavigationGraph.kt
+++ b/feature/home/src/main/java/com/startup/home/navigation/MyPageNavigationGraph.kt
@@ -137,14 +137,15 @@ fun MyPageNavigationGraph(
             ) {
                 composable(MyPageScreenNav.MyInfo.route) {
                     MyInfoScreen(
-                        viewState = myPageViewModel.state,
+                        isProfileAccessFlow = myPageViewModel.state.isProfileAccess,
                         uiEventSender = ::handleMyInfoUiEvent,
                         onNavigationEvent = ::handleNavigationEvent
                     )
                 }
                 composable(MyPageScreenNav.PushSetting.route) {
                     PushSettingScreen(
-                        viewState = myPageViewModel.state,
+                        isNotificationEnabledEggHatchedFlow = myPageViewModel.state.isNotificationEnabledEggHatched,
+                        isNotificationEnabledSpotArriveFlow = myPageViewModel.state.isNotificationEnabledSpotArrive,
                         uiEventSender = ::handlePushSettingUiEvent,
                         onNavigationEvent = ::handleNavigationEvent
                     )


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #179

## 📝작업 내용
- 마이페이지 BaseUiState 래핑
- 나머지 스크린에서도 MyInfoViewState 받고 있던 부분 제거
- 홈-> 마이페이지를 시작페이지로 잡고 3초 딜레이로 체크 했습니다. 웬만하면 스켈레톤 상태 못 볼듯

## ✅체크 사항 (선택)
- 근데 잡아둔 영역이랑, 실제 텍스트 크기가 일치 하지 않아서 살짝 버벅이는 효과가 있긴해요

## 📷스크린샷 (선택)

https://github.com/user-attachments/assets/68ee5ee7-36d2-47ba-baea-7e1eab6cefb8


