### PR TITLE
#183 API 통신 에러 핸들링 처리 변경

### DIFF
--- a/core/data/src/main/java/com/startup/data/remote/ext/RemoteExtension.kt
+++ b/core/data/src/main/java/com/startup/data/remote/ext/RemoteExtension.kt
@@ -12,8 +12,8 @@ internal suspend fun <T : BaseResponse<R>, R> FlowCollector<R>.emitRemote(
     if (specificErrorCode != null && item.status == specificErrorCode) {
         throw ResponseErrorException(item.message.orEmpty(), item.status)
     }
-    if (item.status !in 200..299) {
-        throw ResponseErrorException(item.message.orEmpty(), (item.status ?: -1))
+    if (item.status != null && item.status !in 200..299) {
+        throw ResponseErrorException(item.message.orEmpty(), (item.status))
     }
     emit(item.data.requireNotNull())
 }

--- a/core/data/src/main/java/com/startup/data/util/DataUtil.kt
+++ b/core/data/src/main/java/com/startup/data/util/DataUtil.kt
@@ -5,7 +5,7 @@ import com.google.gson.JsonParseException
 import com.startup.common.util.ClientException
 import com.startup.common.util.NetworkTemporaryException
 import com.startup.common.util.NoCharacterException
-import com.startup.common.util.SessionExpireException
+import com.startup.common.util.ResponseErrorException
 import com.startup.common.util.UnknownException
 import retrofit2.HttpException
 import java.io.InterruptedIOException
@@ -34,6 +34,7 @@ fun handleException(e: Throwable): Throwable {
             else -> throw e
         }
 
+        is ResponseErrorException -> throw e
         is NoCharacterException -> throw e
         is SocketTimeoutException,
         is ConnectException,

--- a/feature/login/src/main/kotlin/com/startup/login/login/LoginViewModel.kt
+++ b/feature/login/src/main/kotlin/com/startup/login/login/LoginViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.viewModelScope
 import com.startup.common.base.BaseViewModel
 import com.startup.common.provider.ResourceProvider
+import com.startup.common.util.ClientException
 import com.startup.common.util.ResponseErrorException
 import com.startup.common.util.UserAccountWithdrawnException
 import com.startup.common.util.UserAuthNotFoundException
@@ -55,7 +56,7 @@ class LoginViewModel @Inject constructor(
                         _state.placeHolder.update { nickName }
                     }
                     notifyEvent(LoginScreenNavigationEvent.MoveToNickNameSettingScreen)
-                } else if ((exception is ResponseErrorException && exception.code == 401) || (exception is HttpException && exception.code() == 401)) {
+                } else if ((exception is ResponseErrorException && exception.code == 401) || (exception is HttpException && exception.code() == 401) || (exception is ClientException && exception.code == 401)) {
                     _errorDialog.update { UserAccountWithdrawnException() }
                 }
             }.onEach {


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #183 

## 📝작업 내용
- 주 설명은 #183 에 했습니다!
- handleExceptionIfNeed 없던 부분들 체크했습니다!
- 탈퇴처리 급하게 막았던 부분들 handleExceptionIfNeed 감싸면서 ClientException 도 고려해야 할 것 같아 추가
   - 이론상 HttpException, ClientException 도 제거할만한데... 일단은.. 이전 상태 유지도 해야하고 탈퇴 현상 동일하게 만들면 서버분들한테 탈퇴 복구 시켜달라고 해야해서,, 일단 틀어막는 방법으로 추가했습니다

## ✅체크 사항 (선택)
-

## 📷스크린샷 (선택)

