### PR TITLE
#171 자정에 걸음수 초기화 로직 추가

### DIFF
--- a/core/domain/src/main/java/com/startup/domain/provider/StepDataStore.kt
+++ b/core/domain/src/main/java/com/startup/domain/provider/StepDataStore.kt
@@ -17,6 +17,8 @@ interface StepDataStore {
     suspend fun isLastResetToday(): Boolean
     suspend fun saveLastResetDate()
     suspend fun saveTodaySteps(steps: Int)
+    suspend fun addTodaySteps(stepsToAdd: Int)
     suspend fun getTodaySteps(): Int
     suspend fun resetTodaySteps()
+    suspend fun checkAndResetForNewDay(): Int?
 }

--- a/feature/home/src/main/java/com/startup/home/main/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/startup/home/main/HomeViewModel.kt
@@ -179,9 +179,6 @@ class HomeViewModel @Inject constructor(
     }
 
     init {
-        viewModelScope.launch(Dispatchers.IO) {
-            stepCounter.checkAndResetForNewDay()
-        }
         observeEggHatchingEvents()
         processUserInfo()
         setupTargetSteps()

--- a/feature/stepcounter/src/main/java/com/startup/stepcounter/broadcastReciver/DailyResetReceiver.kt
+++ b/feature/stepcounter/src/main/java/com/startup/stepcounter/broadcastReciver/DailyResetReceiver.kt
@@ -3,8 +3,10 @@ package com.startup.stepcounter.broadcastReciver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import dagger.hilt.android.AndroidEntryPoint
 import java.lang.ref.WeakReference
 
+@AndroidEntryPoint
 class DailyResetReceiver : BroadcastReceiver() {
 
     interface OnDateChangedListener {
@@ -16,9 +18,8 @@ class DailyResetReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         if (context == null || intent == null) return
 
-
         when (intent.action) {
-            Intent.ACTION_DATE_CHANGED -> {
+            Intent.ACTION_DATE_CHANGED -> {  // 동적 등록때만 정상동작
                 notifyDateChanged()
             }
         }

--- a/feature/stepcounter/src/main/java/com/startup/stepcounter/service/StepCounterService.kt
+++ b/feature/stepcounter/src/main/java/com/startup/stepcounter/service/StepCounterService.kt
@@ -7,5 +7,5 @@ interface StepCounterService {
     suspend fun resetEggStep()
     fun startCounting()
     fun stopCounting()
-    suspend fun checkAndResetForNewDay(): Int?  // null이면 오늘 이미 초기화됨, 아니면 이전 걸음 수 반환
+    suspend fun checkAndResetForNewDay(): Int?
 }

--- a/feature/stepcounter/src/main/java/com/startup/stepcounter/service/StepCounterServiceImpl.kt
+++ b/feature/stepcounter/src/main/java/com/startup/stepcounter/service/StepCounterServiceImpl.kt
@@ -35,17 +35,6 @@ class StepCounterServiceImpl @Inject constructor(
     }
 
     override suspend fun checkAndResetForNewDay(): Int? {
-        // 이미 오늘 초기화했는지 확인
-        if (stepDataStore.isLastResetToday()) {
-            return null  // 이미 초기화됨
-        }
-        // 현재 걸음 수 가져오기
-        val currentSteps = stepDataStore.getTodaySteps()
-        // 걸음 수 초기화
-        stepDataStore.resetTodaySteps()
-        // 마지막 초기화 날짜 업데이트
-        stepDataStore.saveLastResetDate()
-        // 이전 걸음 수 반환
-        return currentSteps
+       return stepDataStore.checkAndResetForNewDay()
     }
 }

--- a/feature/stepcounter/src/main/java/com/startup/stepcounter/service/WalkieStepForegroundService.kt
+++ b/feature/stepcounter/src/main/java/com/startup/stepcounter/service/WalkieStepForegroundService.kt
@@ -157,10 +157,9 @@ internal class WalkieStepForegroundService @Inject constructor() : Service(), Se
     /**
      * 걸음수 저장 및 notification에 걸음수 업데이트
      */
-    private fun handleSteps(context: Context, eggCurrentStep: Int, todaySteps: Int) {
+    private fun handleSteps(context: Context, eggCurrentStep: Int) {
         serviceScope.launch {
             stepDataStore.saveEggCurrentSteps(eggCurrentStep)
-            stepDataStore.saveTodaySteps(todaySteps)
             val targetSteps = stepDataStore.getHatchingTargetStep()
             val isAlreadyReached = stepDataStore.isTargetReached()
 
@@ -189,16 +188,16 @@ internal class WalkieStepForegroundService @Inject constructor() : Service(), Se
             val stepGap = currentSensorValue - lastSensorValue
             if (stepGap > 0) {
                 serviceScope.launch {
+
+                    stepDataStore.checkAndResetForNewDay()
                     val currentEggSteps = stepDataStore.getEggCurrentSteps()
                     val newSteps = currentEggSteps + stepGap
 
-                    val todaySteps = stepDataStore.getTodaySteps()
-                    val newTodayStep = todaySteps + stepGap
+                    stepDataStore.addTodaySteps(stepGap)
 
                     handleSteps(
                         this@WalkieStepForegroundService,
                         eggCurrentStep = newSteps,
-                        todaySteps = newTodayStep
                     )
                 }
             }
@@ -208,7 +207,7 @@ internal class WalkieStepForegroundService @Inject constructor() : Service(), Se
 
     private fun handleAccelerometerSensor(event: SensorEvent) {
         stepDetector.handleAccelerometerSensor(event) {
-            handleSteps(this, 0, 0)
+            handleSteps(this, 0)
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #171

## 📝작업 내용
- 자정 초기화 시점에 이전 걸음수 초기화가 되도록 관련 처리 로직 추가

## ✅체크 사항 (선택)
시도방법

1. ACTION_DATE_CHANGED 를 정적으로 등록하여 자동으로 초기화 시도 
정적으로 등록시에는 해당 Intent Action이 들어오지않음 대안으로 Time_tick , changed시도하였으나, 부정확

https://stackoverflow.com/questions/23928415/android-system-date-changed-event/48782963#48782963

https://stackoverflow.com/questions/21758246/android-action-date-changed-broadcast/21980389


2. alarmMnager를 통해서 부정확하지만 자정시점에 초기화 시도 
너무 부정확하기도 하고, 초기화시점이 다른 걸음수 앱과 차이남 이걸 위해서 정확한 알림권한을 요청하기에는 오버스펙이라고 판단

- 최종 방법
다른 프로젝트 참고한 것처럼 걸음수 감지시마다 관련 체크 로직 추가

## 📷스크린샷 (선택)

https://github.com/user-attachments/assets/a982c8ea-6536-439b-b4ba-6917c568e765


