### PR TITLE
#187 알 이펙트 노출 / 앱 진입시 부화 애니메이션 / 스플래시 로고 위치 조정

### DIFF
--- a/feature/home/src/main/java/com/startup/home/main/screen/HomeScreen.kt
+++ b/feature/home/src/main/java/com/startup/home/main/screen/HomeScreen.kt
@@ -48,11 +48,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.startup.common.base.BaseUiState
+import com.startup.common.extension.formatWithLocale
 import com.startup.common.extension.moveToAppDetailSetting
 import com.startup.common.extension.shimmerEffect
 import com.startup.common.extension.shimmerEffectGray200
-import com.startup.common.base.BaseUiState
-import com.startup.common.extension.formatWithLocale
 import com.startup.common.extension.withBold
 import com.startup.common.extension.withUnderline
 import com.startup.design_system.ui.WalkieTheme
@@ -65,10 +65,10 @@ import com.startup.home.HomeScreenNavigationEvent
 import com.startup.home.R
 import com.startup.home.main.HomeViewState
 import com.startup.model.character.WalkieCharacter
-import com.startup.model.egg.EggLayoutModel
-import com.startup.model.egg.getEggLayoutModel
 import com.startup.model.egg.EggKind
+import com.startup.model.egg.EggLayoutModel
 import com.startup.model.egg.MyEggModel
+import com.startup.model.egg.getEggLayoutModel
 import com.startup.model.home.HistoryItemModel
 
 data class HomePermissionState(
@@ -614,7 +614,7 @@ private fun EggContent(
         val eggSize = minOf(screenWidth - 12.dp, maxEggSize) // 좌우 패딩 6dp씩 고려
 
         // 이펙트 이미지
-        if (eggModel.eggKind == EggKind.Empty) {
+        if (eggModel.eggKind != EggKind.Empty) {
             eggAttribute.effectDrawable?.let { drawableRes ->
                 Image(
                     modifier = Modifier

--- a/feature/login/src/main/kotlin/com/startup/login/splash/SplashActivity.kt
+++ b/feature/login/src/main/kotlin/com/startup/login/splash/SplashActivity.kt
@@ -6,10 +6,11 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -18,12 +19,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.times
 import androidx.lifecycle.lifecycleScope
 import com.startup.common.base.BaseActivity
-import com.startup.login.R
-import com.startup.navigation.HomeModuleNavigator
 import com.startup.design_system.ui.WalkieTheme
+import com.startup.login.R
 import com.startup.login.login.LoginActivity
+import com.startup.navigation.HomeModuleNavigator
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.AndroidEntryPoint
@@ -83,22 +85,27 @@ class SplashActivity : BaseActivity<SplashUiEvent, SplashNavigationEvent>() {
 
 @Composable
 private fun SplashScreenCompose() {
-    Box(
+    BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.White),
-        contentAlignment = Alignment.Center
+        contentAlignment = Alignment.TopCenter
     ) {
-        Column {
-            Spacer(Modifier.height(60.dp))
+        val screenHeight = maxHeight
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Spacer(Modifier.height((240.dp / 780.dp) * screenHeight))
+
             Image(
                 painter = painterResource(id = R.drawable.ic_logo),
-                contentDescription = "앱 로고"
+                contentDescription = "앱 로고",
+                modifier = Modifier.height(200.dp)
             )
         }
     }
 }
-
 
 @PreviewScreenSizes
 @Composable


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #187

## 📝작업 내용
-  5/19 기준 빠르게 처리할 수 있는 잔여 QA들 처리하였습니다.

## ✅체크 사항 (선택)
- 부화 애니메이션같은 경우에는 앱 진입시 부화처리될때 부화애니메이션 보여주게끔 해줬고, 기존에는 부화애니메이션만 뜨고 걸음수 업로드가 안될 것 같아서 관련 처리 로직 넣어줬습니다. 
- 자꾸 eggId가 0일때 ( 같이 걷는 알이 없을때), 걸음수업로드 API 쏘지 않도록 분기 하나 넣어줬습니다.

## 📷스크린샷 (선택)
- 알 이펙트 

![KakaoTalk_20250519_203542054_01](https://github.com/user-attachments/assets/9537b3b3-a076-4ba7-80f6-0bb1754e79ac)|![KakaoTalk_20250519_203542054](https://github.com/user-attachments/assets/ffac72ec-2956-4a8f-8d8b-6441e22c3128)|![KakaoTalk_20250519_203542054_02](https://github.com/user-attachments/assets/51bda668-aa48-419f-96db-2c1ee7051f42)
---|---|---|

- 스플래시 로고 위치 조정

![KakaoTalk_20250519_203954102](https://github.com/user-attachments/assets/230b5089-52b5-4511-9f06-135b50f0576d) | ![화면 캡처 2025-05-19 205332](https://github.com/user-attachments/assets/8986fe94-65cb-4d56-95af-3d300addea5e)
---|---|
