### PR TITLE
#189 안드로이드 15 대응 및 상단바 테마 고정

### DIFF
--- a/core/resource/src/main/res/values/themes.xml
+++ b/core/resource/src/main/res/values/themes.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Walkie" parent="android:Theme.Material.Light.NoActionBar" >
+    <style name="Theme.Walkie" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:windowBackground">@color/white</item>
+        <item name="android:windowLightStatusBar">true</item>
 
     </style>
 
     <style name="Theme.Walkie.Splash" parent="android:Theme.Material.Light.NoActionBar">
         <item name="postSplashScreenTheme">@style/Theme.Walkie</item>
+        <item name="android:windowLightStatusBar">true</item>
         <item name="windowSplashScreenBackground">@color/white</item>
     </style>
 

--- a/feature/login/src/main/kotlin/com/startup/login/splash/SplashActivity.kt
+++ b/feature/login/src/main/kotlin/com/startup/login/splash/SplashActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -87,6 +88,7 @@ class SplashActivity : BaseActivity<SplashUiEvent, SplashNavigationEvent>() {
 private fun SplashScreenCompose() {
     BoxWithConstraints(
         modifier = Modifier
+            .safeDrawingPadding()
             .fillMaxSize()
             .background(Color.White),
         contentAlignment = Alignment.TopCenter

--- a/feature/spot/src/main/java/com/startup/spot/SpotScreen.kt
+++ b/feature/spot/src/main/java/com/startup/spot/SpotScreen.kt
@@ -10,6 +10,7 @@ import android.webkit.WebViewClient
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -72,6 +73,7 @@ internal fun SpotScreen(
     }
     Column(
         modifier = Modifier
+            .safeDrawingPadding()
             .fillMaxSize()
             .background(WalkieTheme.colors.white)
     ) {

--- a/feature/spot/src/main/java/com/startup/spot/modify/ModifySpotScreen.kt
+++ b/feature/spot/src/main/java/com/startup/spot/modify/ModifySpotScreen.kt
@@ -8,6 +8,7 @@ import android.webkit.WebViewClient
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -60,6 +61,7 @@ internal fun ModifySpotScreen(
     }
     Column(
         modifier = Modifier
+            .safeDrawingPadding()
             .fillMaxSize()
             .background(WalkieTheme.colors.white)
     ) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #189

## 📝작업 내용
- 무언가 체크는 많이했는데 기본적으로 scaffold 내부에 
```kotlin
                    .windowInsetsPadding(
                        WindowInsets.systemBars.only(WindowInsetsSides.Vertical)
                    ),

```

이 처리가 되어있어서 로그인이랑 홈액티비티는 처리가 필요 없었습니다. 스플래시랑 웹뷰쪽만 safeDrawingPadding 줘서 15 대응 해두었습니다!

다만, 안드로이드 15에서는 statusbar icon이 windowLightStatusBar 속성이 변동이 생겨서 투명하게 보였던것 같아요 디자인 요구대로 모두 어둡게 해두었습니다.

## ✅참고 자료 (선택)
혹시모르니까 15이전 버전 폰으로 한번만 봐주세요! 저는 13폰으로는 한번 확인했습니다!

- https://www.youtube.com/watch?v=gIUe2OOzohw&t=1s
- https://stackoverflow.com/questions/78832208/how-to-change-the-status-bar-color-in-android-15

클로드는 이렇게 말하는데, 
safeDrawingPadding: 단순히 시스템 UI 요소와 겹치지 않도록 합니다
safeContentPadding: 제스처 혼동(gesture confusion)이 없는 안전한 영역에만 콘텐츠를 그립니다
safeContentPadding 가 살짝 더 넓은 느낌인것 같아요

## 📷스크린샷 (선택)
- 전 / 후

![image](https://github.com/user-attachments/assets/fa9536e5-c2a4-4b21-92fb-ebeb3631af75) | ![image](https://github.com/user-attachments/assets/0b77661f-a961-4a2c-8b55-973091d4dd9e)
---| ---|