### PR TITLE
#193 알 부화 이후 홈 새로고침 및, 같이 걷고 있는 알 없는 경우 목표걸음수 0 되도록 수정

### DIFF
--- a/core/common/src/main/java/com/startup/common/event/EventContainer.kt
+++ b/core/common/src/main/java/com/startup/common/event/EventContainer.kt
@@ -13,6 +13,11 @@ object EventContainer {
 
     val hatchingAnimationFlow: SharedFlow<Boolean> = _hatchingAnimationFlow.asSharedFlow()
 
+    private val _updateNotificationFlow = MutableSharedFlow<Boolean>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val updateNotificationFlow = _updateNotificationFlow.asSharedFlow()
 
     private val _homeRefreshEventFlow = MutableSharedFlow<Unit>(
         extraBufferCapacity = 1,
@@ -28,4 +33,9 @@ object EventContainer {
     suspend fun onRefreshEvent() {
         _homeRefreshEventFlow.emit(Unit)
     }
+
+    suspend fun triggerNotificationUpdate() {
+        _updateNotificationFlow.emit(true)
+    }
+
 }

--- a/feature/home/src/main/java/com/startup/home/HomeActivity.kt
+++ b/feature/home/src/main/java/com/startup/home/HomeActivity.kt
@@ -295,8 +295,6 @@ class HomeActivity : BaseActivity<UiEvent, NavigationEvent>(),
         val navController = rememberNavController()
         val snackBarHostState = SnackbarHostState()
 
-        val hatchingInfo by viewModel.hatchingInfo.collectAsStateWithLifecycle()
-
         Scaffold(
             snackbarHost = {
                 // 원래 코드 유지
@@ -400,23 +398,21 @@ class HomeActivity : BaseActivity<UiEvent, NavigationEvent>(),
                 }
             }
 
-            hatchingInfo.let {
-                val hatchingInfoState by viewModel.hatchingInfo.collectAsStateWithLifecycle()
+            val hatchingInfoState by viewModel.hatchingInfo.collectAsStateWithLifecycle()
 
-                if (hatchingInfoState.data.isHatching) {
-                    val character = hatchingInfoState.data.character
-                    val eggKind = hatchingInfoState.data.eggKind
+            if (hatchingInfoState.data.isHatching) {
+                val character = hatchingInfoState.data.character
+                val eggKind = hatchingInfoState.data.eggKind
 
-                    val characterName = stringResource(id = character.characterNameResId)
-                    val eggRank = eggKind.ordinal - 1
+                val characterName = stringResource(id = character.characterNameResId)
+                val eggRank = eggKind.ordinal - 1
 
-                    EggHatchingAnimation(
-                        characterName = characterName,
-                        characterImageResId = character.characterImageResId,
-                        eggRank = eggRank,
-                        onDismiss = { viewModel.onHatchingAnimationDismissed() }
-                    )
-                }
+                EggHatchingAnimation(
+                    characterName = characterName,
+                    characterImageResId = character.characterImageResId,
+                    eggRank = eggRank,
+                    onDismiss = { viewModel.onHatchingAnimationDismissed() }
+                )
             }
         }
     }

--- a/feature/stepcounter/src/main/java/com/startup/stepcounter/service/WalkieStepForegroundService.kt
+++ b/feature/stepcounter/src/main/java/com/startup/stepcounter/service/WalkieStepForegroundService.kt
@@ -62,6 +62,7 @@ internal class WalkieStepForegroundService @Inject constructor() : Service(), Se
         super.onCreate()
         initStepSensor()
         startForegroundService()
+        observeNotificationUpdateEvents()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -153,6 +154,22 @@ internal class WalkieStepForegroundService @Inject constructor() : Service(), Se
             }
         }
     }
+
+    private fun observeNotificationUpdateEvents() {
+        serviceScope.launch {
+            EventContainer.updateNotificationFlow.collect {
+                val currentSteps = stepDataStore.getEggCurrentSteps()
+                val targetStep = 0
+
+                updateStepNotification(
+                    this@WalkieStepForegroundService,
+                    currentSteps,
+                    targetStep
+                )
+            }
+        }
+    }
+
 
     /**
      * 걸음수 저장 및 notification에 걸음수 업데이트


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #193 

## 📝작업 내용
- 같이 걷고 있는 알이 없으면 목표걸음수 0이 되도록 수정

## ✅체크 사항 (선택)
- 같이 걷고 있는 알이 없어서 needStep이 null (viewmodel에서는 0) 이 들어오면 filter에서 막혀서 목표걸음수 초기화가 제대로 안되고 있어서 수정했습니다. 부화 이후에 명시적으로 새로고침도 넣어줬습니다.


https://github.com/Team-walkies/Walkie-Android/issues/193 [걸음수 notification 바로 초기화 되도록 수정](https://github.com/Team-walkies/Walkie-Android/pull/194/commits/2d32180294030dab5f04c80b5327dbba582200b9)

추가로 부화 완료 시점에서 바로 notification 업데이트하도록 로직도 넣어놨는데 이건 좀 애매하네요... 넣을지 말지 고민되긴 합니다.

## 📷스크린샷 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Step notifications are now updated immediately when egg step data is refreshed, ensuring more timely and accurate information.

- **Improvements**
	- The home screen refreshes automatically after step data updates, providing users with the latest progress without manual intervention.
	- Hatching target steps are now set regardless of step requirements, streamlining the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->