### PR TITLE
#202 포그라운드에서 부화시 엉뚱한 알이 부화되는 현상 수정 / 캐릭터 상세보기 보유마리수 연결

### DIFF
--- a/feature/home/src/main/java/com/startup/home/character/HatchingCharacterScreen.kt
+++ b/feature/home/src/main/java/com/startup/home/character/HatchingCharacterScreen.kt
@@ -653,7 +653,7 @@ private fun CharacterInfoTags(characterDetail: WalkieCharacterDetail) {
                 .padding(vertical = 8.dp, horizontal = 16.dp)
         ) {
             Text(
-                text = stringResource(R.string.format_int, 1), // 임시로 1로 고정
+                text = stringResource(R.string.format_int, characterDetail.character.count),
                 style = WalkieTheme.typography.head6.copy(color = colors.gray700),
             )
             Text(

--- a/feature/home/src/main/java/com/startup/home/main/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/startup/home/main/HomeViewModel.kt
@@ -197,9 +197,10 @@ class HomeViewModel @Inject constructor(
                             eggKind = _state.currentWalkEggUiState.value.data.eggKind
                         )
                     )
-                    _state.userInfo.value?.let {
+                    val currentEggState = _state.currentWalkEggUiState.value
+                    if (!currentEggState.isShowShimmer && currentEggState.data.eggId != 0L) {
                         updateEggWithLocationData(
-                            it.eggId,
+                            currentEggState.data.eggId,
                             dataStore.getEggCurrentSteps()
                         )
                     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #202

## 📝작업 내용
- 재현 경로

포그라운드에서 알선택-> 알 부화 걸음수까지 채움 -> 부화 -> 부화애니메이션 및 리프레시, 걸음수 업로드 처리 

이때, 걸음수 업로드는 userInfo 정보를 사용하는데 얘는 홈 리프레시에 의해서 정보가 업데이트 되지않아서 걸음수 업로드 ( v1/egg/step)이 업데이트되어있지 않은 eggId를 부화처리시킴! 이로 인해 엉뚱한 알이 부화되고 선택된 알은 play 가 true인 상태로 남아버림

refersh로 갱신되는 eggId 정보를 쓰도록 수정

## ✅체크 사항 (선택)
- 이거 고치면서 캐릭터 상세보기 바텀시트에 마리수 페칭 안되어있길래 같이 수정했습니다!

## 📷스크린샷 (선택)

https://github.com/user-attachments/assets/9007ef5d-0998-404e-b6e8-948a798e433f

![image](https://github.com/user-attachments/assets/f5745379-04ed-48a6-826d-287550918fb7) | ![image](https://github.com/user-attachments/assets/dd9a2efc-3f5f-4dbf-8e0b-c4e7692b07c1)
---|---|