### PR TITLE
#205 알 부화처리시 최신 알 정보를 가져오도록 수정 / 알 바꿀때 현재 걸음수를 서버에 업로드 하고 바꾸도록 수정

### DIFF
--- a/core/model/src/main/java/com/startup/model/egg/MyEggModel.kt
+++ b/core/model/src/main/java/com/startup/model/egg/MyEggModel.kt
@@ -34,6 +34,17 @@ data class MyEggModel(
             )
         )
 
+        fun empty() = MyEggModel(
+            eggKind = EggKind.Empty,
+            obtainedDate = "",
+            obtainedPosition = "",
+            eggId = 0,
+            play = false,
+            nowStep = 0,
+            needStep = 0,
+            walkieCharacter = WalkieCharacter.ofEmpty()
+        )
+
         fun List<MyEggModel>.currentPlayEgg(): MyEggModel? = find { it.play }
     }
 

--- a/feature/home/src/main/java/com/startup/home/egg/GainEggViewModel.kt
+++ b/feature/home/src/main/java/com/startup/home/egg/GainEggViewModel.kt
@@ -1,13 +1,15 @@
 package com.startup.home.egg
 
 import androidx.lifecycle.viewModelScope
+import com.startup.common.base.BaseUiState
 import com.startup.common.base.BaseViewModel
 import com.startup.common.event.EventContainer
-import com.startup.common.util.Printer
-import com.startup.domain.provider.StepDataStore
-import com.startup.common.base.BaseUiState
 import com.startup.common.event.EventContainer.triggerNotificationUpdate
+import com.startup.common.util.Printer
+import com.startup.domain.model.egg.UpdateStepData
+import com.startup.domain.provider.StepDataStore
 import com.startup.domain.usecase.egg.GetGainEggList
+import com.startup.domain.usecase.egg.UpdateEggOfStepCount
 import com.startup.domain.usecase.walk.UpdateWalkingEgg
 import com.startup.model.egg.MyEggModel.Companion.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,13 +21,16 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class GainEggViewModel @Inject constructor(
     getGainEggList: GetGainEggList,
     private val updateWalkingEgg: UpdateWalkingEgg,
+    private val updateEggOfStepCount: UpdateEggOfStepCount,
     private val dataStore: StepDataStore
 ) : BaseViewModel() {
 
@@ -44,13 +49,38 @@ class GainEggViewModel @Inject constructor(
     override val state: GainEggViewState get() = _state
 
     fun updateEgg(eggId: Long, needStep: Int, nowStep: Int) {
+        viewModelScope.launch {
+            val currentWalkEggId = dataStore.getCurrentWalkEggId()
+            if (currentWalkEggId != 0L && currentWalkEggId != eggId) {
+                val currentSteps = dataStore.getEggCurrentSteps()
+
+                updateEggOfStepCount.invoke(
+                    UpdateStepData(
+                        eggId = currentWalkEggId,
+                        nowStep = currentSteps
+                    )
+                ).onCompletion {
+                    // 저장 완료 후 새로운 알로 변경
+                    updateNewEgg(eggId, needStep, nowStep)
+                }.catch {
+                    Printer.e("GainEggViewModel", "Failed to save previous egg steps")
+                    updateNewEgg(eggId, needStep, nowStep)
+                }.launchIn(viewModelScope)
+            } else {
+                // 이전 알이 없으면 바로 새로운 알로 변경
+                updateNewEgg(eggId, needStep, nowStep)
+            }
+        }
+    }
+
+    private fun updateNewEgg(eggId: Long, needStep: Int, nowStep: Int) {
         updateWalkingEgg.invoke(eggId)
             .onEach {
                 notifyViewModelEvent(GainEggViewModelEvent.FetchEggList)
                 EventContainer.onRefreshEvent()
                 if (needStep > 0) {
                     dataStore.setHatchingTargetStep(target = needStep)
-                    dataStore.saveEggCurrentSteps(steps = nowStep) // 알이 변경되었으므로 걸음수를 eggModel의 nowStep으로 초기화
+                    dataStore.saveEggCurrentSteps(steps = nowStep)
                     dataStore.setCurrentWalkEggId(eggId = eggId)
                     triggerNotificationUpdate(targetStep = needStep)
                     Printer.d(


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #205

## 📝작업 내용
- 알을 선택하고 앱을 나갔다 들어오지 않으면 같이 걷고 있는 알 정보가 갱신되지 않아서 발생한 문제였습니다. 알을 바꾼 후 걸음수를 채워도 이전 알이 부화가되는 경우도 있어서 부화애니메이션 발동시에는 같이 걷고 있는 알정보를 갱신하도록 수정해주었습니다.
- 알을 바꿀때, 현재 걷고 있는 걸음수 정보가 업로드 되지않아 일부 걸음수가 사라지는 현상이 있었습니다. 그래서 알을 바꿀때는 현재 걸음수를 서버에 전송하고 알을 바꾸도록 수정하였습니다.

## ✅체크 사항 (선택)
- 서버통신이 좀 과도해지는것 같긴한데... 더 좋은 방법 있을까요? 

## 📷스크린샷 (선택)



- 같이걷고 있는 알 최신화 추가 전

https://github.com/user-attachments/assets/45264a1a-3578-4b0f-829d-e943a88ae40d

- 같이걷고 있는 알 최신화 추가 후

https://github.com/user-attachments/assets/44a177cc-3d3a-44c3-a8c9-c3dc43407249

- 걸음수 업로드 추가 전 

https://github.com/user-attachments/assets/7a21cad5-93b1-47cd-9517-059e519a0a36

- 걸음수 업로드 추가 후

https://github.com/user-attachments/assets/4120d122-c2b2-4175-a36c-f8d2a2a2106d




