### PR TITLE
#206 KSP 기반 Hilt 오류 해결

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -12,7 +13,7 @@ java {
 
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = "17"
     }
 }
 
@@ -21,7 +22,6 @@ dependencies {
     implementation(libs.kotlin.gradlePlugin)
     implementation(libs.compose.gradlePlugin)
     implementation(libs.room.gradlePlugin)
-    implementation(libs.hilt.gradlePlugin)
     implementation(libs.ksp.gradlePlugin)
     implementation(libs.google.services.gradlePlugin)
     implementation(libs.firebase.crashlytics.gradlePlugin)

--- a/build-logic/convention/src/main/java/com/startup/convention/walkie.hilt.gradle.kts
+++ b/build-logic/convention/src/main/java/com/startup/convention/walkie.hilt.gradle.kts
@@ -1,3 +1,0 @@
-import com.startup.convention.walkie.configureHiltAndroid
-
-configureHiltAndroid()

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -5,6 +5,4 @@ plugins {
 
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
-    ksp(libs.hilt.compiler)
-    implementation(libs.hilt.core)
 }

--- a/core/ga/build.gradle.kts
+++ b/core/ga/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.walkie.android.library)
     alias(libs.plugins.walkie.firebase)
     alias(libs.plugins.walkie.compose.library)
-    alias(libs.plugins.walkie.hilt)
 }
 
 android {

--- a/feature/home/src/main/java/com/startup/home/HomeActivity.kt
+++ b/feature/home/src/main/java/com/startup/home/HomeActivity.kt
@@ -50,12 +50,9 @@ import com.startup.home.permission.PermissionManager
 import com.startup.home.permission.PermissionUiEvent
 import com.startup.navigation.LoginModuleNavigator
 import com.startup.navigation.SpotModuleNavigator
-import dagger.hilt.EntryPoint
-import dagger.hilt.InstallIn
 import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.EntryPointAccessors
-import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class HomeActivity : BaseActivity<UiEvent, NavigationEvent>(),
@@ -65,12 +62,8 @@ class HomeActivity : BaseActivity<UiEvent, NavigationEvent>(),
 
     private lateinit var permissionManager: PermissionManager
 
-    private val dateChangeNotifier: DateChangeNotifier by lazy {
-        EntryPointAccessors.fromApplication(
-            applicationContext,
-            DateChangeNotifierEntryPoint::class.java
-        ).dateChangeNotifier()
-    }
+    @Inject
+    lateinit var dateChangeNotifier: DateChangeNotifier
 
     // Activity Result Launchers - 권한 관련 Intent 처리용
     private val settingsLauncher = registerForActivityResult(
@@ -87,27 +80,14 @@ class HomeActivity : BaseActivity<UiEvent, NavigationEvent>(),
         permissionManager.proceedToNotification()
     }
 
-    // KSP는 필드 주입이 안 되므로 EntryPoint 사용
-    private val loginModuleNavigator: LoginModuleNavigator by lazy {
-        EntryPointAccessors.fromApplication(
-            applicationContext,
-            LoginNavigatorEntryPoint::class.java
-        ).loginNavigatorNavigator()
-    }
+    @Inject
+    lateinit var loginModuleNavigator: LoginModuleNavigator
 
-    private val spotModuleNavigator: SpotModuleNavigator by lazy {
-        EntryPointAccessors.fromApplication(
-            applicationContext,
-            SpotNavigatorEntryPoint::class.java
-        ).spotNavigatorNavigator()
-    }
+    @Inject
+    lateinit var spotModuleNavigator: SpotModuleNavigator
 
-    private val analyticsHelper: AnalyticsHelper by lazy {
-        EntryPointAccessors.fromApplication(
-            applicationContext,
-            AnalyticsHelperEntryPoint::class.java
-        ).analyticsHelper()
-    }
+    @Inject
+    lateinit var analyticsHelper: AnalyticsHelper
 
     private val permissionCallbacks = object : PermissionManager.PermissionManagerCallbacks {
         override fun startStepCounterService() {
@@ -353,29 +333,5 @@ class HomeActivity : BaseActivity<UiEvent, NavigationEvent>(),
     override fun navigateToLogin() {
         loginModuleNavigator.navigateLoginView(this)
         finish()
-    }
-
-    @EntryPoint
-    @InstallIn(SingletonComponent::class)
-    interface DateChangeNotifierEntryPoint {
-        fun dateChangeNotifier(): DateChangeNotifier
-    }
-
-    @EntryPoint
-    @InstallIn(SingletonComponent::class)
-    interface SpotNavigatorEntryPoint {
-        fun spotNavigatorNavigator(): SpotModuleNavigator
-    }
-
-    @EntryPoint
-    @InstallIn(SingletonComponent::class)
-    interface AnalyticsHelperEntryPoint {
-        fun analyticsHelper(): AnalyticsHelper
-    }
-
-    @EntryPoint
-    @InstallIn(SingletonComponent::class)
-    interface LoginNavigatorEntryPoint {
-        fun loginNavigatorNavigator(): LoginModuleNavigator
     }
 }

--- a/feature/login/src/main/kotlin/com/startup/login/login/LoginActivity.kt
+++ b/feature/login/src/main/kotlin/com/startup/login/login/LoginActivity.kt
@@ -39,27 +39,22 @@ import com.startup.login.login.model.LoginScreenNavigationEvent
 import com.startup.login.login.model.LoginUiEvent
 import com.startup.login.login.model.NickNameSettingEvent
 import com.startup.login.navigation.LoginScreenNav
-import com.startup.login.splash.SplashActivity
 import com.startup.navigation.HomeModuleNavigator
 import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class LoginActivity : BaseActivity<LoginUiEvent, LoginNavigationEvent>() {
     override val viewModel: LoginViewModel by viewModels()
 
-    // KSP 는 필드 주입이 안 됨
-    private val homeModuleNavigator: HomeModuleNavigator by lazy {
-        EntryPointAccessors.fromApplication(
-            applicationContext,
-            SplashActivity.HomeModuleNavigatorEntryPoint::class.java
-        ).homeModuleNavigator()
-    }
+    @Inject
+    lateinit var homeModuleNavigator: HomeModuleNavigator
+
     private val kaKaoLoginClient by lazy { KaKaoLoginClient() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -207,5 +202,4 @@ class LoginActivity : BaseActivity<LoginUiEvent, LoginNavigationEvent>() {
             }
         }
     }
-
 }

--- a/feature/login/src/main/kotlin/com/startup/login/splash/SplashActivity.kt
+++ b/feature/login/src/main/kotlin/com/startup/login/splash/SplashActivity.kt
@@ -27,28 +27,19 @@ import com.startup.design_system.ui.WalkieTheme
 import com.startup.login.R
 import com.startup.login.login.LoginActivity
 import com.startup.navigation.HomeModuleNavigator
-import dagger.hilt.EntryPoint
-import dagger.hilt.InstallIn
 import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.EntryPointAccessors
-import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SplashActivity : BaseActivity<SplashUiEvent, SplashNavigationEvent>() {
     override val viewModel: SplashViewModel by viewModels<SplashViewModel>()
 
-
-    // KSP 는 필드 주입이 안 됨
-    private val homeModuleNavigator: HomeModuleNavigator by lazy {
-        EntryPointAccessors.fromApplication(
-            applicationContext,
-            HomeModuleNavigatorEntryPoint::class.java
-        ).homeModuleNavigator()
-    }
+    @Inject
+    lateinit var homeModuleNavigator: HomeModuleNavigator
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -75,13 +66,6 @@ class SplashActivity : BaseActivity<SplashUiEvent, SplashNavigationEvent>() {
     }
 
     override fun handleUiEvent(uiEvent: SplashUiEvent) {}
-
-
-    @EntryPoint
-    @InstallIn(SingletonComponent::class)
-    interface HomeModuleNavigatorEntryPoint {
-        fun homeModuleNavigator(): HomeModuleNavigator
-    }
 }
 
 @Composable

--- a/feature/spot/src/main/java/com/startup/spot/SpotActivity.kt
+++ b/feature/spot/src/main/java/com/startup/spot/SpotActivity.kt
@@ -8,27 +8,21 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.startup.common.base.BaseActivity
-import com.startup.navigation.LoginModuleNavigator
 import com.startup.design_system.ui.WalkieTheme
-import dagger.hilt.EntryPoint
-import dagger.hilt.InstallIn
+import com.startup.navigation.LoginModuleNavigator
 import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.EntryPointAccessors
-import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SpotActivity : BaseActivity<SpotUiEvent, SpotNavigationEvent>() {
     override val viewModel: SpotViewModel by viewModels<SpotViewModel>()
-    private val loginModuleNavigator: LoginModuleNavigator by lazy {
-        EntryPointAccessors.fromApplication(
-            applicationContext,
-            LoginNavigatorEntryPoint::class.java
-        ).loginNavigatorNavigator()
-    }
+
+    @Inject
+    lateinit var loginModuleNavigator: LoginModuleNavigator
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -73,11 +67,5 @@ class SpotActivity : BaseActivity<SpotUiEvent, SpotNavigationEvent>() {
     override fun navigateToLogin() {
         loginModuleNavigator.navigateLoginView(this)
         finish()
-    }
-
-    @EntryPoint
-    @InstallIn(SingletonComponent::class)
-    interface LoginNavigatorEntryPoint {
-        fun loginNavigatorNavigator(): LoginModuleNavigator
     }
 }

--- a/feature/spot/src/main/java/com/startup/spot/modify/ModifyReviewActivity.kt
+++ b/feature/spot/src/main/java/com/startup/spot/modify/ModifyReviewActivity.kt
@@ -8,31 +8,25 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.startup.common.base.BaseActivity
+import com.startup.design_system.ui.WalkieTheme
 import com.startup.navigation.LoginModuleNavigator
+import com.startup.spot.BuildConfig
 import com.startup.spot.ModifyReviewEvent
 import com.startup.spot.ModifyReviewNavigationEvent
 import com.startup.spot.ModifyReviewUiEvent
-import com.startup.design_system.ui.WalkieTheme
-import com.startup.spot.BuildConfig
-import dagger.hilt.EntryPoint
-import dagger.hilt.InstallIn
 import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.EntryPointAccessors
-import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class ModifyReviewActivity : BaseActivity<ModifyReviewUiEvent, ModifyReviewNavigationEvent>() {
     override val viewModel: ModifyReviewViewModel by viewModels<ModifyReviewViewModel>()
-    private val loginModuleNavigator: LoginModuleNavigator by lazy {
-        EntryPointAccessors.fromApplication(
-            applicationContext,
-            LoginNavigatorEntryPoint::class.java
-        ).loginNavigatorNavigator()
-    }
+
+    @Inject
+    lateinit var  loginModuleNavigator: LoginModuleNavigator
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -78,11 +72,5 @@ class ModifyReviewActivity : BaseActivity<ModifyReviewUiEvent, ModifyReviewNavig
     override fun navigateToLogin() {
         loginModuleNavigator.navigateLoginView(this)
         finish()
-    }
-
-    @EntryPoint
-    @InstallIn(SingletonComponent::class)
-    interface LoginNavigatorEntryPoint {
-        fun loginNavigatorNavigator(): LoginModuleNavigator
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.6.0"
+agp = "8.6.1"
 kotlin = "2.1.10"
 coreKtx = "1.15.0"                        # https://kotlinlang.org/docs/releases.html
 coroutine = "1.8.1"
@@ -10,9 +10,9 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.0"
 composeBom = "2025.01.00"
-ksp = "2.1.10-1.0.29"
+ksp = "2.1.10-1.0.31"
 room = "2.6.1"
-hilt = "2.52"
+hilt = "2.56.1"
 androidxHiltNavigationCompose = "1.2.0"
 androidxLifecycle = "2.8.7"
 androidxNavigation = "2.8.4"
@@ -123,7 +123,6 @@ firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "
 # Plugins defined by this project
 walkie-android-application = { id = "walkie.android.application", version = "unspecified" }
 walkie-android-feature = { id = "walkie.feature", version = "unspecified" }
-walkie-hilt = { id = "walkie.hilt", version = "unspecified" }
 walkie-android-library-compose = { id = "walkie.android.library.compose", version = "unspecified" }
 walkie-android-library = { id = "walkie.android.library", version = "unspecified" }
 walkie-kotlin-library = { id = "walkie.kotlin.library", version = "unspecified" }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #206 

## 📝작업 내용
- pre-compiled gradle plugin 개발 시 영향을 끼치는 이슈
   - 플러그인 형태로 넣는 경우, (convention 모듈 build.gradle.kts 확인) "kotlin-dsl" 플러그인이 코틀린 버전을 강제화 하는 이슈가 있어서 hilt 버전과 코틀린 버전이 일치하지 않는 이슈가 있었음
   - 어차피 hilt 는 플러그인 형태로 넣지 않기 때문에 제거
- 라이브러리 버전 이슈로 인한 문제로 현재 해결 하였습니다.
   - agp, hilt, ksp 버전업
- 이외 나머지
  - domain layer 에서 hilt 의존성 제거 -> 어차피 추가 중
  - convention 모듈 build.gradle.kts  에서 jvmTarget 세팅을 JavaVersion.VERSION_17.toString() 으로 넣고 잇었음
  - EntryPointAccessors 코드 제거, PR 중 새로 추가된건 rebase 할 때 제거해둘게요

## ✅체크 사항 (선택)
-

## 📷스크린샷 (선택)

