### PR TITLE
#232 FCM 기본 세팅

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -118,7 +118,13 @@
                     android:scheme="kakao${NATIVE_APP_KEY}" />
             </intent-filter>
         </activity>
-
+        <service
+            android:name=".WalkieFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/com/startup/walkie/WalkieApplication.kt
+++ b/app/src/main/kotlin/com/startup/walkie/WalkieApplication.kt
@@ -23,6 +23,7 @@ class WalkieApplication : Application() {
         initializeLogging()
         initialRemoteConfigSetting()
         KakaoSdk.init(this, BuildConfig.NATIVE_APP_KEY)
+//        fetchFirebaseMessagingToken()
     }
 
     private fun initializeLogging() {
@@ -45,4 +46,18 @@ class WalkieApplication : Application() {
             remoteConfig.setDefaultsAsync(R.xml.remote_config_defaults)
         }
     }
+
+//    private fun fetchFirebaseMessagingToken(){
+//        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
+//            if (!task.isSuccessful) {
+//                Printer.d("LMH", "Fetching FCM registration token failed ${task.exception}")
+//                return@OnCompleteListener
+//            }
+//
+//            // Get new FCM registration token
+//            val token = task.result
+//
+//            Printer.d("LMH", token)
+//        })
+//    }
 }

--- a/app/src/main/kotlin/com/startup/walkie/WalkieFirebaseMessagingService.kt
+++ b/app/src/main/kotlin/com/startup/walkie/WalkieFirebaseMessagingService.kt
@@ -1,0 +1,16 @@
+package com.startup.walkie
+
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.startup.common.util.Printer
+
+class WalkieFirebaseMessagingService: FirebaseMessagingService() {
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        Printer.d("WalkieFirebaseMessagingService", message.data.entries.joinToString())
+        super.onMessageReceived(message)
+    }
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+    }
+}

--- a/build-logic/convention/src/main/java/com/startup/convention/walkie/Firebase.kt
+++ b/build-logic/convention/src/main/java/com/startup/convention/walkie/Firebase.kt
@@ -15,6 +15,7 @@ internal fun Project.configureFirebaseApp() {
         add("implementation", libs.findLibrary("firebase.analytics").get())
         add("implementation", libs.findLibrary("firebase.crashlytics").get())
         add("implementation", libs.findLibrary("firebase.config").get())
+        add("implementation", libs.findLibrary("firebase-messaging").get())
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -105,6 +105,7 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 firebase-config = { group = "com.google.firebase", name = "firebase-config" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 kakao-login = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao-sdk" }
 lottie = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottie" }
 leakcanary-android = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #232

## 📝작업 내용
- FCM 콘솔에서 보냈을 때 알림을 받을 수 있도록 작업하였습니다.
- 해당 버전이 배포 된 이후로는 콘솔에서 메세지를 보냈을 때 noti-only 메세지로 전송이 되어 모두에게 표출이 가능해집니다.
- 추후 처리 필요한 메세지가 생기는 경우 서버단에서 작업 하여 data message 보내어 작업하도록 설정하시져!

## ✅체크 사항 (선택)
-

## 📷스크린샷 (선택)
![Screenshot_20250629_152328_One UI Home](https://github.com/user-attachments/assets/ceda165e-963f-4c96-a573-658abf55d199)


