### PR TITLE
#227 : 하루에 한번 알 획득 API 호출 로직 추가

### DIFF
--- a/core/data/src/main/java/com/startup/data/datasource/EggDataSource.kt
+++ b/core/data/src/main/java/com/startup/data/datasource/EggDataSource.kt
@@ -1,5 +1,6 @@
 package com.startup.data.datasource
 
+import com.startup.data.remote.dto.response.egg.DailyEggResponse
 import com.startup.data.remote.dto.response.egg.EggCountResponse
 import com.startup.data.remote.dto.response.egg.EggDetailDto
 import com.startup.data.remote.dto.response.egg.MyEggResponse
@@ -12,4 +13,5 @@ interface EggDataSource {
     fun updateEggOfStepCount(request: UpdateEggOfStepCountRequest): Flow<EggStepUpdateResponse>
     fun getMyEggList(): Flow<MyEggResponse>
     fun getMyEggCount(): Flow<EggCountResponse>
+    fun getDailyEgg(): Flow<DailyEggResponse>
 }

--- a/core/data/src/main/java/com/startup/data/local/datasourceimpl/StepDataStoreImpl.kt
+++ b/core/data/src/main/java/com/startup/data/local/datasourceimpl/StepDataStoreImpl.kt
@@ -30,6 +30,7 @@ class StepDataStoreImpl @Inject constructor(
         private val TARGET_STEP = intPreferencesKey("target_step")
         private val TARGET_REACHED = booleanPreferencesKey("target_reached")
         private val LAST_RESET_TIME = longPreferencesKey("last_reset_time")
+        private val LAST_DAILY_API_CALL = longPreferencesKey("last_daily_api_call")
     }
 
     private var cachedLastResetDayStart: Long = 0  // 마지막 리셋 날짜의 자정 시간
@@ -168,5 +169,22 @@ class StepDataStoreImpl @Inject constructor(
         saveLastResetDate()
         // 이전 걸음 수 반환
         return currentSteps
+    }
+
+    override suspend fun shouldCallDailyApi(): Boolean {
+        // 임시: 항상 true 반환 (테스트용)
+        //return true
+        
+         val lastApiCall = context.dataStore.data.first()[LAST_DAILY_API_CALL] ?: 0L
+         val currentTime = System.currentTimeMillis()
+        // 한 번도 호출하지 않았거나, 마지막 호출이 오늘이 아닌 경우
+         return lastApiCall == 0L || !isSameDay(lastApiCall, currentTime)
+    }
+
+    override suspend fun markDailyApiCalled() {
+        val currentTime = System.currentTimeMillis()
+        context.dataStore.edit { preferences ->
+            preferences[LAST_DAILY_API_CALL] = currentTime
+        }
     }
 }

--- a/core/data/src/main/java/com/startup/data/remote/datasourceimpl/EggDataSourceImpl.kt
+++ b/core/data/src/main/java/com/startup/data/remote/datasourceimpl/EggDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.startup.data.remote.datasourceimpl
 
 import com.startup.data.datasource.EggDataSource
 import com.startup.data.remote.dto.request.egg.UpdateEggOfStepCountRequest
+import com.startup.data.remote.dto.response.egg.DailyEggResponse
 import com.startup.data.remote.dto.response.egg.EggCountResponse
 import com.startup.data.remote.dto.response.egg.EggDetailDto
 import com.startup.data.remote.dto.response.egg.EggStepUpdateResponse
@@ -38,6 +39,12 @@ internal class EggDataSourceImpl @Inject constructor(private val eggService: Egg
     override fun getMyEggCount(): Flow<EggCountResponse> = flow {
         handleExceptionIfNeed {
             emitRemote(eggService.getMyEggCount())
+        }
+    }
+
+    override fun getDailyEgg(): Flow<DailyEggResponse> = flow {
+        handleExceptionIfNeed {
+            emitRemote(eggService.getDailyEgg())
         }
     }
 }

--- a/core/data/src/main/java/com/startup/data/remote/dto/response/egg/DailyEggResponse.kt
+++ b/core/data/src/main/java/com/startup/data/remote/dto/response/egg/DailyEggResponse.kt
@@ -1,0 +1,16 @@
+package com.startup.data.remote.dto.response.egg
+
+import com.google.gson.annotations.SerializedName
+import com.startup.domain.model.egg.DailyEgg
+
+data class DailyEggResponse(
+    @SerializedName("receivedToday")
+    val receivedToday: Boolean?,
+    @SerializedName("remainingDays")
+    val remainingDays: Int?
+) {
+    fun toDomain() = DailyEgg(
+        receivedToday = receivedToday ?: false,
+        remainingDays = remainingDays ?: 0
+    )
+}

--- a/core/data/src/main/java/com/startup/data/remote/service/EggService.kt
+++ b/core/data/src/main/java/com/startup/data/remote/service/EggService.kt
@@ -2,6 +2,7 @@ package com.startup.data.remote.service
 
 import com.startup.data.remote.BaseResponse
 import com.startup.data.remote.dto.request.egg.UpdateEggOfStepCountRequest
+import com.startup.data.remote.dto.response.egg.DailyEggResponse
 import com.startup.data.remote.dto.response.egg.EggCountResponse
 import com.startup.data.remote.dto.response.egg.EggDetailDto
 import com.startup.data.remote.dto.response.egg.EggStepUpdateResponse
@@ -27,5 +28,9 @@ internal interface EggService {
     /** 보유한 알 갯수 조회 API */
     @GET("api/v1/eggs/count")
     suspend fun getMyEggCount(): BaseResponse<EggCountResponse>
+
+    /** 하루에 한번 알 획득 API */
+    @GET("api/v1/events/daily-egg")
+    suspend fun getDailyEgg(): BaseResponse<DailyEggResponse>
 
 }

--- a/core/data/src/main/java/com/startup/data/repository/EggRepositoryImpl.kt
+++ b/core/data/src/main/java/com/startup/data/repository/EggRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.startup.data.repository
 import com.startup.common.extension.orZero
 import com.startup.data.datasource.EggDataSource
 import com.startup.data.remote.dto.request.egg.UpdateEggOfStepCountRequest
+import com.startup.domain.model.egg.DailyEgg
 import com.startup.domain.model.egg.EggDetail
 import com.startup.domain.model.egg.MyEgg
 import com.startup.domain.model.egg.UpdateEggStepInfo
@@ -46,4 +47,7 @@ internal class EggRepositoryImpl @Inject constructor(
 
     override fun getMyEggCount(): Flow<Int> =
         eggDataSource.getMyEggCount().map { it.eggCount.orZero() }
+
+    override fun getDailyEgg(): Flow<DailyEgg> =
+        eggDataSource.getDailyEgg().map { it.toDomain() }
 }

--- a/core/design-system/src/main/java/com/startup/design_system/widget/modal/EventModal.kt
+++ b/core/design-system/src/main/java/com/startup/design_system/widget/modal/EventModal.kt
@@ -1,0 +1,238 @@
+package com.startup.design_system.widget.modal
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.startup.design_system.R
+import com.startup.design_system.ui.WalkieTheme
+import com.startup.design_system.ui.noRippleClickable
+
+@Composable
+fun EventModal(
+    title: Int = R.string.event_gift_title,
+    subTitle: Int = R.string.event_until_end,
+    positiveText: Int = R.string.dialog_positive,
+    negativeText: Int? = null,
+    dayCount: Int? = null,
+    imageRes: Int? = null,
+    backOrOutSideDismissBlock: Boolean = false,
+    onClickPositive: () -> Unit,
+    onClickNegative: (() -> Unit)? = null,
+    onDismiss: () -> Unit
+) {
+    val configuration = LocalConfiguration.current
+    val screenHeight = configuration.screenHeightDp.dp
+    val imageHeight = remember { screenHeight * 0.25f }
+    val imageWidth = remember { imageHeight * 1.18f }
+    Dialog(
+        onDismissRequest = { onDismiss() },
+        properties = DialogProperties(
+            dismissOnBackPress = !backOrOutSideDismissBlock,
+            dismissOnClickOutside = !backOrOutSideDismissBlock,
+        )
+    ) {
+        Card(
+            colors = CardDefaults.cardColors(containerColor = WalkieTheme.colors.white),
+            shape = RoundedCornerShape(24.dp),
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(top = 0.dp, bottom = 16.dp, start = 16.dp, end = 16.dp)
+                    .background(WalkieTheme.colors.white),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                imageRes?.let { imageResId ->
+                    Image(
+                        painter = painterResource(id = imageResId),
+                        contentDescription = "Event Icon",
+                        modifier = Modifier
+                            .height(imageHeight)
+                            .width(imageWidth)
+                            .aspectRatio(1.18f)
+                    )
+                }
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    stringResource(title),
+                    style = WalkieTheme.typography.head5.copy(
+                        color = WalkieTheme.colors.gray700,
+                        textAlign = TextAlign.Center
+                    )
+                )
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        stringResource(subTitle),
+                        style = WalkieTheme.typography.body2.copy(
+                            color = WalkieTheme.colors.blue400,
+                            textAlign = TextAlign.Center,
+                        )
+                    )
+                    dayCount?.let { count ->
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Box(
+                            modifier = Modifier
+                                .background(
+                                    WalkieTheme.colors.blue50,
+                                    RoundedCornerShape(4.dp)
+                                )
+                                .wrapContentWidth()
+                                .padding(horizontal = 8.dp, vertical = 4.dp)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.event_day_count, count),
+                                style = WalkieTheme.typography.body2.copy(
+                                    color = WalkieTheme.colors.blue400,
+                                    textAlign = TextAlign.Center
+                                )
+                            )
+                        }
+                    }
+                }
+                Spacer(Modifier.height(20.dp))
+                if (negativeText != null && onClickNegative != null) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(48.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .background(
+                                    WalkieTheme.colors.gray100,
+                                    RoundedCornerShape(12.dp)
+                                )
+                                .weight(1F)
+                                .padding(vertical = 13.dp)
+                                .noRippleClickable {
+                                    onClickNegative.invoke()
+                                }
+                        ) {
+                            Text(
+                                modifier = Modifier
+                                    .wrapContentSize()
+                                    .align(Alignment.Center),
+                                text = stringResource(negativeText),
+                                style = WalkieTheme.typography.body1,
+                                textAlign = TextAlign.Center,
+                                color = WalkieTheme.colors.gray500,
+                            )
+                        }
+
+                        Box(
+                            modifier = Modifier
+                                .background(
+                                    WalkieTheme.colors.blue300,
+                                    RoundedCornerShape(12.dp)
+                                )
+                                .weight(1F)
+                                .padding(vertical = 13.dp)
+                                .noRippleClickable {
+                                    onClickPositive.invoke()
+                                }
+                        ) {
+                            Text(
+                                modifier = Modifier
+                                    .wrapContentSize()
+                                    .align(Alignment.Center),
+                                text = stringResource(positiveText),
+                                style = WalkieTheme.typography.body1,
+                                textAlign = TextAlign.Center,
+                                color = WalkieTheme.colors.white,
+                            )
+                        }
+                    }
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .background(
+                                WalkieTheme.colors.blue300,
+                                RoundedCornerShape(12.dp)
+                            )
+                            .fillMaxWidth()
+                            .padding(vertical = 13.dp)
+                            .noRippleClickable {
+                                onClickPositive.invoke()
+                            }
+                    ) {
+                        Text(
+                            modifier = Modifier
+                                .wrapContentSize()
+                                .align(Alignment.Center),
+                            text = stringResource(positiveText),
+                            style = WalkieTheme.typography.body1,
+                            textAlign = TextAlign.Center,
+                            color = WalkieTheme.colors.white,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewEventModal() {
+    WalkieTheme {
+        EventModal(
+            title = R.string.event_gift_title,
+            positiveText = R.string.event_show,
+            negativeText = R.string.dialog_dismiss,
+            dayCount = 21,
+            imageRes = R.drawable.img_gift,
+            onDismiss = {},
+            onClickPositive = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewEventModalTwoButton() {
+    WalkieTheme {
+        EventModal(
+            title = R.string.event_gift_title,
+            subTitle = R.string.event_until_end,
+            positiveText = R.string.event_show,
+            negativeText = R.string.dialog_dismiss,
+            dayCount = 21,
+            imageRes = R.drawable.img_gift,
+            onDismiss = {},
+            onClickPositive = {},
+            onClickNegative = {}
+        )
+    }
+}

--- a/core/domain/src/main/java/com/startup/domain/model/egg/DailyEgg.kt
+++ b/core/domain/src/main/java/com/startup/domain/model/egg/DailyEgg.kt
@@ -1,0 +1,6 @@
+package com.startup.domain.model.egg
+
+data class DailyEgg(
+    val receivedToday: Boolean,
+    val remainingDays: Int
+)

--- a/core/domain/src/main/java/com/startup/domain/provider/StepDataStore.kt
+++ b/core/domain/src/main/java/com/startup/domain/provider/StepDataStore.kt
@@ -23,4 +23,8 @@ interface StepDataStore {
     suspend fun getTodaySteps(): Int
     suspend fun resetTodaySteps()
     suspend fun checkAndResetForNewDay(): Int?
+    
+    // 일일 API 호출 관련
+    suspend fun shouldCallDailyApi(): Boolean
+    suspend fun markDailyApiCalled()
 }

--- a/core/domain/src/main/java/com/startup/domain/repository/EggRepository.kt
+++ b/core/domain/src/main/java/com/startup/domain/repository/EggRepository.kt
@@ -1,5 +1,6 @@
 package com.startup.domain.repository
 
+import com.startup.domain.model.egg.DailyEgg
 import com.startup.domain.model.egg.EggDetail
 import com.startup.domain.model.egg.MyEgg
 import com.startup.domain.model.egg.UpdateEggStepInfo
@@ -11,4 +12,5 @@ interface EggRepository {
     fun updateEggOfStepCount(request: UpdateStepData): Flow<UpdateEggStepInfo>
     fun getMyEggList(): Flow<List<MyEgg>>
     fun getMyEggCount(): Flow<Int>
+    fun getDailyEgg(): Flow<DailyEgg>
 }

--- a/core/domain/src/main/java/com/startup/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/startup/domain/repository/UserRepository.kt
@@ -12,4 +12,5 @@ interface UserRepository {
     fun getProfileAccessEnabled(): Flow<Boolean>
     suspend fun updateProfileAccessEnabled(enabled: Boolean)
     suspend fun getMinAppVersionCode(): Long
+    suspend fun isEggEventEnabled(): Boolean
 }

--- a/core/domain/src/main/java/com/startup/domain/usecase/egg/GetDailyEgg.kt
+++ b/core/domain/src/main/java/com/startup/domain/usecase/egg/GetDailyEgg.kt
@@ -1,0 +1,12 @@
+package com.startup.domain.usecase.egg
+
+import com.startup.domain.model.egg.DailyEgg
+import com.startup.domain.repository.EggRepository
+import com.startup.domain.usecase.base.BaseUseCase
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetDailyEgg @Inject constructor(private val eggRepository: EggRepository) :
+    BaseUseCase<DailyEgg, Unit>() {
+    override fun invoke(params: Unit): Flow<DailyEgg> = eggRepository.getDailyEgg()
+}

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -208,6 +208,7 @@
     <string name="permission_dialog_negative">취소</string>
     <string name="permission_dialog_positive">허용하기</string>
     <string name="dialog_positive">확인</string>
+    <string name="dialog_dismiss">닫기</string>
 
     <string name="unlink_header_title">탈퇴하기</string>
     <string name="unlink_title">%s이 떠나시다니,\n너무 아쉬워요</string>
@@ -228,4 +229,9 @@
     <string name="bottomsheet_force_update_sub_title">유저분들의 의견을 반영하여 사용성을 개선했어요!\n지금 바로 업데이트하고 즐겨보세요</string>
     <string name="bottomsheet_force_update_negative_btn">앱을 종료할게요</string>
     <string name="dialog_force_update_positive_btn">업데이트</string>
+
+    <string name="event_show">보러가기</string>
+    <string name="event_day_count">D-%d</string>
+    <string name="event_gift_title">알 1개를 선물 받았어요!</string>
+    <string name="event_until_end">이벤트 종료까지</string>
 </resources>

--- a/core/resource/src/main/res/xml/remote_config_defaults.xml
+++ b/core/resource/src/main/res/xml/remote_config_defaults.xml
@@ -4,4 +4,8 @@
     <key>AOS_MIN_APP_VERSION</key>
     <value>1</value>
   </entry>
+  <entry>
+    <key>EGG_EVENT_ENABLED</key>
+    <value>false</value>
+  </entry>
 </defaults>

--- a/feature/home/src/main/java/com/startup/home/HomeActivity.kt
+++ b/feature/home/src/main/java/com/startup/home/HomeActivity.kt
@@ -36,7 +36,9 @@ import com.startup.common.base.UiEvent
 import com.startup.common.util.BatteryOptimizationHelper
 import com.startup.common.util.OsVersions
 import com.startup.common.util.UsePermissionHelper
+import com.startup.design_system.R
 import com.startup.design_system.ui.WalkieTheme
+import com.startup.design_system.widget.modal.EventModal
 import com.startup.domain.provider.DateChangeListener
 import com.startup.domain.provider.DateChangeNotifier
 import com.startup.ga.AnalyticsHelper
@@ -138,6 +140,8 @@ class HomeActivity : BaseActivity<UiEvent, NavigationEvent>(),
         super.onCreate(savedInstanceState)
         setupPermissionManager()
         registerDailyResetReceiver()
+        viewModel.callDailyApiAndCheckEvent()
+
         setContent {
             WalkieTheme {
                 MainScreenWithPermissionComponents()
@@ -183,6 +187,24 @@ class HomeActivity : BaseActivity<UiEvent, NavigationEvent>(),
                     context = this@HomeActivity,
                     permissionManager = permissionManager
                 )
+
+                val eventState by viewModel.eventState.collectAsStateWithLifecycle()
+
+                if (eventState.showEventModal) {
+                    EventModal(
+                        title = R.string.event_gift_title,
+                        subTitle = R.string.event_until_end,
+                        positiveText = R.string.event_show,
+                        negativeText = R.string.dialog_dismiss,
+                        dayCount = eventState.eventRemainingDays,
+                        imageRes = R.drawable.img_gift,
+                        onDismiss = { viewModel.onEventModalDismissed() },
+                        onClickPositive = {
+                            viewModel.navigateToGainEggFromEventModal()
+                        },
+                        onClickNegative = { viewModel.onEventModalDismissed() }
+                    )
+                }
             }
         }
     }
@@ -313,7 +335,9 @@ class HomeActivity : BaseActivity<UiEvent, NavigationEvent>(),
                     characterName = characterName,
                     characterImageResId = character.characterImageResId,
                     eggRank = eggRank,
-                    onDismiss = { viewModel.onHatchingAnimationDismissed() }
+                    onDismiss = {
+                        viewModel.onHatchingAnimationDismissed()
+                    }
                 )
             }
         }

--- a/feature/home/src/main/java/com/startup/home/MainBottomNavigationScreen.kt
+++ b/feature/home/src/main/java/com/startup/home/MainBottomNavigationScreen.kt
@@ -113,6 +113,14 @@ fun MainBottomNavigationScreen(
         }
     }
 
+    LaunchedEffect(Unit) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            homeViewModel.navigateToGainEgg.collect {
+                navController.navigate(MainScreenNav.HomeGraph.route + "/${HomeScreenNav.GainEgg.route}")
+            }
+        }
+    }
+
     fun handleHomeScreenNavigationEvent(navigationEvent: HomeScreenNavigationEvent) {
         when (navigationEvent) {
             HomeScreenNavigationEvent.MoveToGainEgg -> {

--- a/feature/home/src/main/java/com/startup/home/permission/PermissionInduction.kt
+++ b/feature/home/src/main/java/com/startup/home/permission/PermissionInduction.kt
@@ -30,12 +30,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.startup.common.extension.moveToNotificationSetting
 import com.startup.common.util.BatteryOptimizationHelper
 import com.startup.common.util.UsePermissionHelper
 import com.startup.common.util.rememberPermissionRequestDelegator
+import com.startup.design_system.ui.WalkieTheme
 import com.startup.design_system.widget.button.PrimaryButton
 import com.startup.home.R
-import com.startup.design_system.ui.WalkieTheme
 
 data class PermissionState(
     val type: UsePermissionHelper.Permission,
@@ -205,11 +206,16 @@ fun NotificationPermissionBottomSheet(
     onNeverAskAgain: (List<String>) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
+
     val notificationPermissionDelegator = rememberPermissionRequestDelegator(
         permissions = listOf(UsePermissionHelper.Permission.POST_NOTIFICATIONS),
         doOnGranted = onAllowPermission,
         doOnShouldShowRequestPermissionRationale = onShowRationale,
-        doOnNeverAskAgain = onNeverAskAgain
+        doOnNeverAskAgain = {
+            context.moveToNotificationSetting()
+            onNeverAskAgain(it)
+        }
     )
 
     PermissionBottomSheetContainer(modifier = modifier) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #227

## 📝작업 내용
- 하루에 한번 알 지급 api를 호출 및 관련 비지니스 로직 추가하였습니다. 
- 추가적으로 알림 바텀시트에 영구거절 동작이 없어서.. 추가해두었습니다.

## ✅체크 사항 (선택)
- 현재 권한 허용 플로우를 타다가 앱을 이탈시 api 호출이 누락되는 경우가 있어서 이부분은 협의하에 우선 앱 진입시 최우선으로 나오도록 설정하였습니다. 또한 단발성 이벤트임을 고려하여 추후 분리가 용이하도록 EventStateUi로 따로 묶었습니다.


## 📷스크린샷 (선택)

https://github.com/user-attachments/assets/92a1a721-1bc5-40f8-9609-8d23c987d1f6

권한 바텀시트와 같이 나올시 
---|
![image](https://github.com/user-attachments/assets/ae03bc5e-8667-44a2-8105-983e6a9fbf89)
