### PR TITLE
#277 [QA] Number OverFlow 이슈

### DIFF
--- a/feature/home/src/main/java/com/startup/home/spot/component/BottomSheetMonthCalendarComponent.kt
+++ b/feature/home/src/main/java/com/startup/home/spot/component/BottomSheetMonthCalendarComponent.kt
@@ -40,6 +40,7 @@ import com.startup.model.spot.WeekendType
 import com.startup.design_system.ui.WalkieTheme
 import com.startup.design_system.ui.noRippleClickable
 import java.time.LocalDate
+import java.time.YearMonth
 
 /** 바텀 시트, Preview 를 위해 뷰 파일과 분리 */
 
@@ -85,9 +86,13 @@ private fun BottomSheetCalendarContent(
         mutableStateOf(selectDateTime)
     }
     val today = LocalDate.now()
-    var isNextMonthEnabled by remember { mutableStateOf(today.isAfter(currentDate)) }
+    var isNextMonthEnabled by remember {
+        mutableStateOf(
+            YearMonth.from(currentDate).isBefore(YearMonth.from(today))
+        )
+    }
     LaunchedEffect(currentDate.month) {
-        isNextMonthEnabled = today.isAfter(currentDate)
+        isNextMonthEnabled = YearMonth.from(currentDate).isBefore(YearMonth.from(today))
         val targetDay = selectDate.dayOfMonth
         val lastDayOfNewMonth = currentDate.lengthOfMonth()
         val correctedDay = minOf(targetDay, lastDayOfNewMonth)


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #277 

## 문제상황
- 월간 달력 이번달의 다음달이 이동되는 현상이 있어서 달력 표시의 Number Overflow가 생기는 현상이 발생 했었습니다.
- isNextMonthEnabled 를 일(day) 도 비교하고 있었음...

## 📝작업 내용
- 월만 비교하도록 수정..!

## ✅체크 사항 (선택)
-

## 📷스크린샷 (선택)


https://github.com/user-attachments/assets/f2ec2564-b240-49d2-9f42-77e434f729fd

