### PR TITLE
#284 noRippleClickable에 디바운스 타임 추가

### DIFF
--- a/core/common/src/main/java/com/startup/common/extension/ComposeExtension.kt
+++ b/core/common/src/main/java/com/startup/common/extension/ComposeExtension.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -73,6 +74,30 @@ fun Modifier.noRippleClickable(
     role = role,
     onClick = onClick,
 )
+
+@Composable
+fun Modifier.noRippleSingleClickable(
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    enabled: Boolean = true,
+    role: Role? = null,
+    debounceTime: Long = 500L,
+    onClick: () -> Unit,
+): Modifier {
+    val lastClickTime = remember { mutableLongStateOf(0L) }
+    return this.clickable(
+        interactionSource = interactionSource,
+        indication = null,
+        enabled = enabled,
+        role = role,
+        onClick = {
+            val currentTime = System.currentTimeMillis()
+            if (currentTime - lastClickTime.longValue > debounceTime) {
+                lastClickTime.longValue = currentTime
+                onClick()
+            }
+        },
+    )
+}
 
 fun TextFieldValue.ofMaxLength(maxLength: Int): TextFieldValue {
     val overLength = text.length - maxLength

--- a/core/design-system/src/main/java/com/startup/design_system/ui/Extension.kt
+++ b/core/design-system/src/main/java/com/startup/design_system/ui/Extension.kt
@@ -4,6 +4,7 @@ import android.graphics.BlurMaskFilter
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -73,3 +74,27 @@ fun Modifier.noRippleClickable(
     role = role,
     onClick = onClick,
 )
+
+@Composable
+fun Modifier.noRippleSingleClickable(
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    enabled: Boolean = true,
+    role: Role? = null,
+    debounceTime: Long = 500L,
+    onClick: () -> Unit,
+): Modifier {
+    val lastClickTime = remember { mutableLongStateOf(0L) }
+    return this.clickable(
+        interactionSource = interactionSource,
+        indication = null,
+        enabled = enabled,
+        role = role,
+        onClick = {
+            val currentTime = System.currentTimeMillis()
+            if (currentTime - lastClickTime.longValue > debounceTime) {
+                lastClickTime.longValue = currentTime
+                onClick()
+            }
+        },
+    )
+}

--- a/feature/home/src/main/java/com/startup/home/healthcare/screen/HealthcareScreen.kt
+++ b/feature/home/src/main/java/com/startup/home/healthcare/screen/HealthcareScreen.kt
@@ -68,6 +68,7 @@ import com.startup.common.util.DateUtil
 import com.startup.common.util.Printer
 import com.startup.design_system.ui.WalkieTheme
 import com.startup.design_system.ui.noRippleClickable
+import com.startup.design_system.ui.noRippleSingleClickable
 import com.startup.design_system.widget.actionbar.PageActionBar
 import com.startup.design_system.widget.actionbar.PageActionBarType
 import com.startup.design_system.widget.badge.EggBadgeStatus
@@ -552,7 +553,7 @@ private fun HealthcareDetailComponent(
                 Column(
                     modifier = Modifier
                         .onGloballyPositioned(onGloballyPositioned)
-                        .noRippleClickable {
+                        .noRippleSingleClickable {
                             when (eggBadgeStatus) {
                                 EggBadgeStatus.AVAILABLE -> {
                                     getEgg.invoke()


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #284 

## 📝작업 내용
- noRippleClickable에 debounce time 추가하여 중복호출되는 경우를 방지하였습니다.

## ✅체크 사항 (선택)
- 처음에는 HealthcareScreen에서만 수정할까 하다가 우선 전역적으로 영향 받도록 넣어놨습니다. 
혹시나 모든 동작에 영향이 우려된다면 기본값을 0으로 해도 될 것 같아요!

## 📷스크린샷 (선택)

https://github.com/user-attachments/assets/810516ca-5151-4603-8cdb-c28eead4c4b2
