### PR TITLE
#289 StepDataStoreImpl 크래시 대응

### DIFF
--- a/core/data/src/main/java/com/startup/data/remote/datasourceimpl/StepDataStoreImpl.kt
+++ b/core/data/src/main/java/com/startup/data/remote/datasourceimpl/StepDataStoreImpl.kt
@@ -7,6 +7,8 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStore
 import com.startup.common.util.DateUtil
 import com.startup.common.util.Printer
@@ -30,7 +32,12 @@ class StepDataStoreImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     private val healthcareService: HealthcareService,
 ) : StepDataStore {
-    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "walkie_settings")
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "walkie_settings",
+        corruptionHandler = ReplaceFileCorruptionHandler {
+            emptyPreferences()
+        }
+    )
 
     private companion object {
         private val TODAY_STEPS = intPreferencesKey("today_steps")


### PR DESCRIPTION
## #️⃣연관된 이슈

- Resolved : #289 

## 📝작업 내용
- 확인해보니 지속적으로 StepDatasotre 설정파일을 가져올때 오류가 생겨서 크래시가 발생하고 있습니다. 

   1. 쓰기 중 중단: 데이터 저장 중에 앱이 강제 종료되거나 배터리가 방전된 경우
   2. 저장 공간 부족: 디스크 공간이 부족하여 파일이 잘린 경우
   3. 파일 시스템 오류: 드물지만 기기의 파일 시스템 자체의 일시적인 오류

근본적으로 해결가능하나 봤는데 저희쪽에서는 예외 대응코드 정도만 해줄수 있을 것 같아 우선 크래시가 발생하지 않도록만 대응하려고 합니다.

[관련 크래시 링크 1](https://console.firebase.google.com/project/walkie-11d1d/crashlytics/app/android:com.startup.walkie/issues/53ff8d027d80cb8a5720351bdcf62f68?hl=ko&time=90d&types=crash&sessionEventKey=695F99DD019E000173202DC471173EE4_2171402276453416692)

[관련 크래시 링크2](https://console.firebase.google.com/project/walkie-11d1d/crashlytics/app/android:com.startup.walkie/issues/a2cf628a24bbb0a6dc43bd3eaea9e642?hl=ko&time=90d&types=crash&sessionEventKey=695F99B6030300015B12DE53D3087566_2171402112063712569)
## ✅체크 사항 (선택)
-

## 📷스크린샷 (선택)

